### PR TITLE
Fix incorrect target size for uploaded image

### DIFF
--- a/chapter3/transfer_learning.ipynb
+++ b/chapter3/transfer_learning.ipynb
@@ -187,7 +187,7 @@
         " \n",
         "  # predicting images\n",
         "  path = '/content/' + fn\n",
-        "  img = image.load_img(path, target_size=(300, 300))\n",
+        "  img = image.load_img(path, target_size=(150, 150))\n",
         "  x = image.img_to_array(img)\n",
         "  x = np.expand_dims(x, axis=0)\n",
         "\n",


### PR DESCRIPTION
The target size for the uploaded image should be same as the target size for the training and validation images.