### PR TITLE
Fix predict classes

### DIFF
--- a/chapter8/first-song.ipynb
+++ b/chapter8/first-song.ipynb
@@ -1,25 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "First Song.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/lmoroney/tfbook/blob/master/chapter8/first-song.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -27,11 +12,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zX4Kg8DUTKWO",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "zX4Kg8DUTKWO"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -44,17 +31,17 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "BOwsuGQQY9OL",
-        "colab": {}
+        "id": "BOwsuGQQY9OL"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -64,17 +51,17 @@
         "from tensorflow.keras.models import Sequential\n",
         "from tensorflow.keras.optimizers import Adam\n",
         "import numpy as np "
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "PRnDnCW-Z7qv",
-        "colab": {}
+        "id": "PRnDnCW-Z7qv"
       },
+      "outputs": [],
       "source": [
         "tokenizer = Tokenizer()\n",
         "\n",
@@ -87,17 +74,17 @@
         "\n",
         "print(tokenizer.word_index)\n",
         "print(total_words)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "soPGVheskaQP",
-        "colab": {}
+        "id": "soPGVheskaQP"
       },
+      "outputs": [],
       "source": [
         "input_sequences = []\n",
         "for line in corpus:\n",
@@ -114,17 +101,17 @@
         "xs, labels = input_sequences[:,:-1],input_sequences[:,-1]\n",
         "\n",
         "ys = tf.keras.utils.to_categorical(labels, num_classes=total_words)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "pJtwVB2NbOAP",
-        "colab": {}
+        "id": "pJtwVB2NbOAP"
       },
+      "outputs": [],
       "source": [
         "print(tokenizer.word_index['in'])\n",
         "print(tokenizer.word_index['the'])\n",
@@ -134,70 +121,70 @@
         "print(tokenizer.word_index['one'])\n",
         "print(tokenizer.word_index['jeremy'])\n",
         "print(tokenizer.word_index['lanigan'])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "49Cv68JOakwv",
-        "colab": {}
+        "id": "49Cv68JOakwv"
       },
+      "outputs": [],
       "source": [
         "print(xs[6])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "iY-jwvfgbEF8",
-        "colab": {}
+        "id": "iY-jwvfgbEF8"
       },
+      "outputs": [],
       "source": [
         "print(ys[6])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "wtzlUMYadhKt",
-        "colab": {}
+        "id": "wtzlUMYadhKt"
       },
+      "outputs": [],
       "source": [
         "print(xs[5])\n",
         "print(ys[5])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "H4myRpB1c4Gg",
-        "colab": {}
+        "id": "H4myRpB1c4Gg"
       },
+      "outputs": [],
       "source": [
         "print(tokenizer.word_index)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "w9vH8Y59ajYL",
-        "colab": {}
+        "id": "w9vH8Y59ajYL"
       },
+      "outputs": [],
       "source": [
         "  model = Sequential()\n",
         "  model.add(Embedding(total_words, 8))\n",
@@ -205,17 +192,17 @@
         "  model.add(Dense(total_words, activation='softmax'))\n",
         "  model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])\n",
         "  history = model.fit(xs, ys, epochs=1500, verbose=1)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "3YXGelKThoTT",
-        "colab": {}
+        "id": "3YXGelKThoTT"
       },
+      "outputs": [],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -225,56 +212,56 @@
         "  plt.xlabel(\"Epochs\")\n",
         "  plt.ylabel(string)\n",
         "  plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "poeprYK8h-c7",
-        "colab": {}
+        "id": "poeprYK8h-c7"
       },
+      "outputs": [],
       "source": [
         "plot_graphs(history, 'accuracy')\n",
         "plot_graphs(history, 'loss')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "6Vc6PHgxa6Hm",
-        "colab": {}
+        "id": "6Vc6PHgxa6Hm"
       },
+      "outputs": [],
       "source": [
         "seed_text = \"in the town of athy\"\n",
         "\n",
         "token_list = tokenizer.texts_to_sequences([seed_text])[0]\n",
         "token_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')\n",
         "#print(model.predict(token_list))  \n",
-        "predicted = model.predict_classes(token_list)\n",
-        "pred_classes=model.predict(token_list)\n",
+        "pred_classes = model.predict(token_list, verbose=0)\n",
+        "predicted = np.argmax(pred_classes, axis=-1)\n",
         "print(pred_classes.reshape(-1)[predicted])\n",
         "print(predicted)\n",
         "for word, index in tokenizer.word_index.items():\n",
         "\tif index == predicted:\n",
         "\t\tprint(word)\n",
         "\t\tbreak\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "HoIRoanzuHwv",
-        "colab": {}
+        "id": "HoIRoanzuHwv"
       },
+      "outputs": [],
       "source": [
         "seed_text = \"sweet jeremy saw dublin\"\n",
         "next_words=10\n",
@@ -284,7 +271,8 @@
         "for _ in range(next_words):\n",
         "\ttoken_list = tokenizer.texts_to_sequences([seed_text])[0]\n",
         "\ttoken_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')\n",
-        "\tpredicted = model.predict_classes(token_list, verbose=0)\n",
+        "\tpred_classes = model.predict(token_list, verbose=0)\n",
+        "\tpredicted = np.argmax(pred_classes, axis=-1)\n",
         "\toutput_word = \"\"\n",
         "\tfor word, index in tokenizer.word_index.items():\n",
         "\t\tif index == predicted:\n",
@@ -293,9 +281,22 @@
         "\tseed_text += \" \" + output_word\n",
         "\n",
         "print(seed_text)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "include_colab_link": true,
+      "name": "First Song.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/chapter8/irish-songs-moredata.ipynb
+++ b/chapter8/irish-songs-moredata.ipynb
@@ -1,24 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "irish-songsmoredata.ipynb",
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "TPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/lmoroney/tfbook/blob/master/chapter8/irish-songs-moredata.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -26,11 +12,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zX4Kg8DUTKWO",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "zX4Kg8DUTKWO"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -43,35 +31,35 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "D1J15Vh_1Jih",
-        "colab_type": "code",
         "cellView": "both",
-        "colab": {}
+        "colab": {},
+        "colab_type": "code",
+        "id": "D1J15Vh_1Jih"
       },
+      "outputs": [],
       "source": [
         "try:\n",
         "  # %tensorflow_version only exists in Colab.\n",
         "  %tensorflow_version 2.x\n",
         "except Exception:\n",
         "  pass\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "BOjujz601HcS",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "BOjujz601HcS"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -81,32 +69,32 @@
         "from tensorflow.keras.models import Sequential\n",
         "from tensorflow.keras.optimizers import Adam\n",
         "import numpy as np "
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "tq0_KqNPaCjQ",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "tq0_KqNPaCjQ"
       },
+      "outputs": [],
       "source": [
         "!wget --no-check-certificate \\\n",
         "    https://storage.googleapis.com/learning-datasets/irish-lyrics-eof.txt \\\n",
         "    -O /tmp/irish-lyrics-eof.txt"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "rNHCNxGLZx99",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "rNHCNxGLZx99"
       },
+      "outputs": [],
       "source": [
         "tokenizer = Tokenizer()\n",
         "max_sequence_len = 6\n",
@@ -149,43 +137,43 @@
         "xs, labels = input_sequences[:,:-1],input_sequences[:,-1]\n",
         "\n",
         "ys = tf.keras.utils.to_categorical(labels, num_classes=total_words)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "8BG-akbfR_MI",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "8BG-akbfR_MI"
       },
+      "outputs": [],
       "source": [
         "print(xs.shape)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "NU58xi445Bjt",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "NU58xi445Bjt"
       },
+      "outputs": [],
       "source": [
         "print(xs[:20])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "uHMeH7mEgJ-X",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "uHMeH7mEgJ-X"
       },
+      "outputs": [],
       "source": [
         "model = Sequential()\n",
         "model.add(Embedding(total_words, 16, input_length=max_sequence_len-1))\n",
@@ -196,21 +184,48 @@
         "model.compile(loss='categorical_crossentropy', optimizer=adam, metrics=['accuracy'])\n",
         "history = model.fit(xs, ys, epochs=100, verbose=1)\n",
         "model.save(\"bidiirish2.h5\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 36,
       "metadata": {
-        "id": "3YXGelKThoTT",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 541
         },
+        "colab_type": "code",
+        "id": "3YXGelKThoTT",
         "outputId": "64236e26-f497-4123-b87e-5d1741edf34b"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxcdb3/8dcne5qmaZqm6d6ktHSnLYQWRJFVCkhxQQVRAcW6oXjVq9zr7+fuzwWvXvXigggCKhVQvL2IcKGAULYutBS6h7Rp06bNvu+Zz++PmZZpm8AUM5kk5/18PPIg58yZmc/JKfOe8/1+z/eYuyMiIsGVlOgCREQksRQEIiIBpyAQEQk4BYGISMApCEREAi4l0QWcqLFjx3phYWGiyxARGVI2bNhQ7e75vT025IKgsLCQ9evXJ7oMEZEhxczK+npMTUMiIgGnIBARCTgFgYhIwCkIREQCTkEgIhJwCgIRkYBTEIiIBJyCQEQGvXV7aln10gFCIU2bHw9xvaDMzJYBPwWSgdvc/fu9bPN+4BuAAy+5+wfjWZOIJJa7s+VAI9PyRpCdkXrUYzXNHQDkjUwHIBRyfvFkCT9+dCchhzuf3cN33jWfORNGxfReDa1d/O/Wg2wub+DzF8w88roDpb2rhzW7qtl+sJEdh5oB+L/vnMO47IyYn5+RmhzPEoE4BoGZJQO3ABcC5cA6M1vl7lujtpkJ/BtwlrvXmdm4eNUjIn3bfrCRioZ2zp6ZT3KSHfVYR3cPe2taKa1uoaymhQP17eyvb6O5vZszpufxjnkFzB6fjdnRz6tsauf7D21nRHoyCyePZvb4UTz7ajV/Wr+P0qoW5kwYxT0fX8roEWkA7DzUxFW3Pk9daydnzRjLO0+ZwN9fOciTO6p416KJnHlSHj94eAfv/Pka3l88mWXzJ7C0aMxxH5TuzpqSam5fs5s1JdV09YTPIrZWNPKH65e+4Qfr7uoWfv74Ljq6QowblU7BqAwuXTCBKWNG9Pmc9q4ekpOM1OTXGlk6unu45va1vLC7FoDJuZnUNHfyYlkdd1x3OicXZB/3Oh3dPTyxvYo1JVU8W1JDaXULly+ayDeXzzvyd4oHi9cdyszsTOAb7n5RZPnfANz9e1Hb/BDY6e63xfq6xcXFrikmRE6Mu9PY3k1tSyejMlKOfDNu7ezmJ4/u5LdrdhNymDFuJJ87fyZvOSmPR7YcZNWmA6zbU0t0i8zI9BQmjc4kNcXYcqARd5iWN4Kbls3m4gUTADhQ38bVt73Agfo20pKTaOroPvL84mm5vG1mPrc8UcKcCdncff1SKhvbufLW50ky472nTeahlysoq2klLTmJr102l6uXTsXMqG/t5OZHdnD/hnI6ukNkpCaxtCiP4mm5nDotF4CfPraLtXtqKRiVzrsWTeKSBRMor2vjM398keULJ/LTKxdhZrg7JZXNpCYnMTY7/Pf4r8dL+O2aUtKSkyjIyaCysYPmjm7Gjkxn5YozmDFu5FF/0xf31nHvunIe3HyAzLRkbvngqSydnkco5PzLvZv4700H+O6757N84USyM1J5ubyBj965jvauHn565SLmTcwhJcmoaenk3nX7+POL5dS1djEiLZkzpucxcXQGK9fuIzcrje+/ZwHnzyl40/8GzGyDuxf3+lgcg+AKYJm7Xx9Z/jCw1N1viNrmr8BO4CzCzUffcPeHe3mtFcAKgKlTp55WVtbnlBkicdHe1cMdz+xh8dTRnDE9L+7v9+SOSn748A5uOG8Gl0Q+XGPh7rR3hWjq6GLT3nrWlFTzTEk1e2tbj3wzBijMG8GpU3NZV1bLvto2rloylaVFY7jliRJ2VTYf2e6k/CwumjeeWeOzKRqbxbS8LHIyX2vOqWrqYPW2Q9z1XBlbKxq5dMEEPva2Ij77x400tnXxu4+ezuIpuZRWt7C1opG5E0Yd+TB9bOshPvn7DcyflMP++jYAVq44g5PyR+LuvLK/kVGZKUzLyzpuP9u7eniutIZ/7KjimZLqo2oel53OZ86dwZVLppCe8tq3/1ueKOHmR3bwibdPJ3dEGvdGzkwOSzIIOVxx2mS+vGzWkeabnYea+OBvwiH1p0+cSdHYLJ7eVcX3/76dLQcaGZGWzKULJrChrI69ta189dI5VDV18IsnX+VfL5rFZ86dcVTt++vbuO6Otew81HzU+pQk4x3zCvjA6VM5c3oeaSnhs4stBxr44r0vsf1gE9+4bC7XnlUU47+Gow3mIHgQ6ALeD0wGngIWuHt9X6+rMwL5Zx1uo36+tIb01GRyMlMpyE7n9MIxJB3TLAKw42ATN67cyPaDTSQZfOHCk/n0OTN63faw5o5ufvTIDp4pqabHnVDIyUhNZlreCArHZjF3wigumFNAVvrxrbNP7qhkxd0bAOjsDvG+0ybz9eXzGBm1bVN7F3c9V8bvnt1DQ1sXBphBR3eI6P+lM1OTWTp9DLPHjyIvK40xWWlUNXewoayOjXvrGJOVxrcvn8/SSLiFQs5Dr1RQUtnMhXMLmDth1HFNPr3p6glx61Ol/PSxXXT2hBg9IpW7P7qUBZNzXvd5D71cwQ1/fJExWemsXLGUGeOOby6JRUNbF5v21VPb0sHF8yf02vzj7nzpvs38+cVyAE4vzOVdiyeRkZJMdXMHda1dXDSvgMVTc4977s5DTVx56/OkJScxs2AkT++qZnJuJjecO4PLFk4kKz2FxvYuvvCnTTy2rRKAq5ZM4f+9e0Gvf7+m9i4e3XqItq4eunuc1OQkLpxbQH52730Ynd0hfvnkq1y5ZAoFo2LrXzhWooIglqahXwEvuPsdkeXVwE3uvq6v11UQSG/au3ro6gkd1/kYrb61k1/9o5SHXq5gb23rcY9//G1FfPXSuUeW3Z3fv7CX7zy4leyMFL59+Xz+/spBVr10gHNm5XP+nAJeLKvjxb115I5I472nTWb5KRN5eX8DX/nzZg40tHHurHFkpiWTbEZLRzd7alrYV9tGZ0+IEWnJXDx/ApctnMCcCaMYl53OU7uq+fhd65mRP5I7P7qEO5/dwy1PljBpdCZLCscwJivcTnzfhnIa2ro4Z1Y+s8ePwnHcIT0liaz0FLLSkpkxLptTp40+6ltxvO081MTta3Zz3VlFzBof24f6xr11jBuVwaTRmXGuLvyB+teN+ykuzGV6/sg3fkKUbRWNfPA3zxNy+Ox5M/jwmdOO+9uGQs6vnyqlvK6Vby6fR0ry4BmYmaggSCHc7HM+sB9YB3zQ3bdEbbMMuMrdrzGzscBGYJG71/T1ugoCiVbT3MHdz5dx93NlNHV08+WLZvHRs4qO+7ZeVtPCdb9bR1lNK2fNGMsl88dz3pzw2ISG1i5uf2Y396zdx08+sJB3L56Mu/ODh3fwq3+8yjmz8rn5ioXkZ6cfCYdv/89WOntC5Genc+rU0ZTVtLL9YBNpyUl09oSYnp/FzVecwmnTxhxXc08o3Lb85w3lPLi5guZI+3lWWjKdPSFmjsvmD9cvJTfyof9CaQ0/+t8dHKhvp6alg/auEBfMGcfnzp/JKZNHx/kvLNFqWzpJTbbX/cIxWCUkCCJvfAnwn4Tb/2939++a2beA9e6+ysLnTP8BLAN6gO+6+8rXe00FQbC0dHRTUtnMpNxMxkYN/XN3fvHkq/xs9S46ukOcN3scBqzeXsnSojHcfMVCpozJxMx4cW8d19+5npA7t364mCVFx384d/WE+NBtL7BxXz33fuJM/ryhnLufL+PqpVP59uXzjwuWioY2urr9yHscbm56YON+RmWk8om3T49p2F9bZw8byuoorW6mtKqFrp4QX3rHrCMh0JuuntBRo1NEYpGwIIgHBcHwVtvSyRPbK3l8eyUvlddTXhfuRMzOSOHmKxaybP54QiHnWw9u5XfP7uGSBeP5woUnM2NcNu7OfRvK+db/bKW5o5uM1CTystKpau5gQk4Gd1x7+us2B9Q0d7D8v56hsqmdrh7nE2dP56aLZ8fURi4y2CkIJGHau3rYW9vKwYZ2FkzK6fWbbkVDGw+/cpC/v3KQ9ZGhiuOy01lSNIZZBdkUjs3iN0+Xsrm8gevfWkRNSycPbNzPx99WxL9fMue4D+ryulYeermC6uZOqps7SE9J4kvvmBXTxURbDzRy7R1r+ciZ0/jMuTMUAjJsKAhkwL1a1cyKu9ZTWt1yZBRLcpLxlpPyuGjeeNq7ethxsImtFY1sOdAIwKyCbN4xr4AL5xYwf2LOUc0xHd09fPdv27jrufDQ4X+9aBafPuekuHxQu7sCQIYdBYEMqJ6Q875fPUtpdQvXvaWIwrEjyMtKZ01J9VEjdsaOTOfkgpGcNWMsy+aP56QYRnE8tvUQnT2hExpbLyKvHwRD7ub1Mvj97tk9vLi3nv/8wCLetXjSkfVvnTmWryybRWl1C6MzU9/UvC8XzH3zV1aKSO8UBHLCDja08/j2SmYWjGT+xBwy014bHVNW08LNj2zn/NnjuHzRxOOea2YxffMXkYGjIJAT8mpVMx++7QUONLQD4Xb/2eOzOWXyaE6ZnMMDG/eTmpTEd/u4olJEBh8FgcRsy4EGPvLbtZjBPR8/g5aObjbtq2fTvnr+tvkA96zdC8D33rOA8Tlv7jJ4ERl4CgI5yr7aVl6taub0wjFH5sFpaOvi4Vcq+M7ftpGdnsLvr196ZDz+4TZ7d6esppWDje0s7eWCLREZvBQEcsSGslquvWMdTe3dpCUncXpRLiPSUvjHjio6e0LMHp/Nb689vdc5YcyMwrFZFI49fqZIERncFAQCwJrIZGfjczL40fsWsn5PLU/uqKK5o4Wrz5jK8oUTWTRltNr9RYYhBUHANbR18eDmA3xz1Vam52dx18eWMC47g4vmjeerlya6OhEZCAqCAHJ3/vZyBfetL+fZV8O38ls8dTR3XHt6XG+HJyKDk4IgYMpqWvg/f32Fp3dVM3XMCD56VhEXzR/PosmjX/dGKyIyfCkIAqCxPXzbwmdereZ3z+whLTmJb18+j6uXTtOHv4goCIYrd+epXdX85NGdvFRej3v4VobL5o3n65fN0zh/ETlCQTAMvbK/ge/9fRvPlNQwZUwmnz//ZE6dNpqFU0YzagjeWUlE4ktBMIx09YT42epd3PJECTmZqXztnXO5+oypA3rPWhEZehQEw0RZTQs3rtzEpn31vPfUyXztsrnkZOrbv4i8MQXBMLB62yFuXLkJM/j5VYu5bOHxs36KiPRFQTCEuTu3PlXK9x/ezvyJOfzqw6f1Ov2DiMjrURAMUZ3dIf79gZe5f0M5ly6YwI/et/Co+wKIiMRKQTAENbV38anfv8iakmo+d/5MPn/+TF0PICJvmoJgiKlsaue6O9ax/WATN19xCu8rnpLokkRkiFMQDCGv7G/g0394kaqmDm67pphzZ41LdEkiMgwoCIaAzu4QP398F7948lXystK4Z8UZLJoyOtFlicgwoSAY5MpqWvjE3RvYfrCJ95w6ia+/cx45I3R9gIj0HwXBILa/vo0P/uYFWjq7ue0jxUduCyki0p8UBINUZWM7V//meRrbu7jn42cwf1JOoksSkWEqKdEFyPHqWjq5+rYXqGzq4HfXLVEIiEhcxTUIzGyZme0wsxIzu6mXx681syoz2xT5uT6e9QwVP129i93VLfz2mtM5bVpuossRkWEubk1DZpYM3AJcCJQD68xslbtvPWbTP7n7DfGqY6ipbelk5bq9XL5oEmeelJfockQkAOJ5RrAEKHH3UnfvBFYCl8fx/YaFu58ro70rxIqzpye6FBEJiHgGwSRgX9RyeWTdsd5rZpvN7H4z6/UyWTNbYWbrzWx9VVVVPGodFNo6e7jzuT2cN3scs8ZnJ7ocEQmIRHcW/w9Q6O6nAI8Cd/a2kbvf6u7F7l6cn58/oAUOpPs37KO2pZNP6GxARAZQPINgPxD9DX9yZN0R7l7j7h2RxduA0+JYz6DWE3J+8/RuFk0ZzZKiMYkuR0QCJJ5BsA6YaWZFZpYGXAmsit7AzCZELS4HtsWxnkHt/g372FvbyiffPh0zzSQqIgMnbqOG3L3bzG4AHgGSgdvdfYuZfQtY7+6rgM+Z2XKgG6gFro1XPYPZqpcO8O8PvELxtFwunDs+0eWISMCYuye6hhNSXFzs69evT3QZ/eb+DeV8+f6XKC4cw+3Xns7IdF3sLSL9z8w2uHtxb4/pUyeB/nvTfr5030u8dcZYfvORYt1hTEQSQkGQIPvr2/jqA6+wpHAMt11TTEaqQkBEEiPRw0cDyd35t7+8TMid/3j/QoWAiCSUgiAB7ltfzlM7q7jp4tlMGTMi0eWISMApCAZYRUMb3/7bVpYWjeFDS6cluhwREQXBQPvOg9vo7nF+eMUpJCXpegERSTwFwQDacqCBv71cwYqzpzMtLyvR5YiIAAqCAfWTR3eSk5nKx95WlOhSRESOUBAMkI1763hsWyUrzp7OqAzdfF5EBg8FwQD58aM7GZOVxrVvKUx0KSIiR1EQDIC1u2t5elc1n3r7SWRpCgkRGWQUBAPg54/vIj87nQ+doeGiIjL4KAjirKSymad3VXPNmdM0l5CIDEoKgjj7/fNlpCUnceWSqYkuRUSkVwqCOGrp6ObPG8q5ZMF4xo5MT3Q5IiK9UhDE0QMb99PU0c2HzyxMdCkiIn1SEMSJu3P3c2XMmziKU6eOTnQ5IiJ9UhDEydrdtew41MQ1ZxbqHsQiMqgpCOLkrufKyMlM5bKFExNdiojI61IQxMHemlb+/koFVy6ZoiGjIjLoKQji4LY1pSQnGR89S5PLicjgpyDoZzXNHdy7fh/vXjyJglEZiS5HROQNKQj62V3PldHeFWLF2dMTXYqISEwUBP2otbObO5/bwwVzCpgxLjvR5YiIxERB0I/uXbeP+tYuPnWOzgZEZOhQEPQTd+fO58o4bVoup00bk+hyRERipiDoJ69WNbO7uoV3LZ6U6FJERE6IgqCfPL69EoDzZo9LcCUiIidGQdBPVm+rZPb4bCaNzkx0KSIiJySuQWBmy8xsh5mVmNlNr7Pde83Mzaw4nvXES0NbF+vL6nQ2ICJDUtyCwMySgVuAi4G5wFVmNreX7bKBG4EX4lVLvD21s4qekHP+HAWBiAw98TwjWAKUuHupu3cCK4HLe9nu28APgPY41hJXT2yvJHdEKoum5Ca6FBGRExZTEJjZX8zsUjM7keCYBOyLWi6PrIt+3VOBKe7+tzd4/xVmtt7M1ldVVZ1ACfHXE3Ke2FHJObPGkZyk6aZFZOiJ9YP9F8AHgV1m9n0zm/XPvnEkVH4MfPGNtnX3W9292N2L8/Pz/9m37leb9tVT19rFueofEJEhKqYgcPfH3P1q4FRgD/CYmT1rZteZWWofT9sPTIlanhxZd1g2MB940sz2AGcAq4Zah/Hj2w+RnGS8febgCigRkVjF3NRjZnnAtcD1wEbgp4SD4dE+nrIOmGlmRWaWBlwJrDr8oLs3uPtYdy9090LgeWC5u69/MzuSKI9vr6J4Wi45I/rKQxGRwS3WPoIHgKeBEcBl7r7c3f/k7p8FRvb2HHfvBm4AHgG2Afe6+xYz+5aZLe+f8hNrf30b2yoaNWxURIa0lBi3+5m7P9HbA+7eZ1OOuz8EPHTMuq/1se05MdYyaBy+mvj8OQUJrkRE5M2LtWlorpmNPrxgZrlm9uk41TRkrN52iMK8EZyUn5XoUkRE3rRYg+Dj7l5/eMHd64CPx6ekoaG1s5tnX63hvNkFmGnYqIgMXbEGQbJFfdpFrhpOi09JQ8OaXdV0doe4QFcTi8gQF2sfwcPAn8zs15HlT0TWBdbqbZVkp6dwepHuPSAiQ1usQfAVwh/+n4osPwrcFpeKhoBQyFm9vZKzZ+WTmqwJXEVkaIspCNw9BPwy8hN4m/c3UN3coWYhERkWYgoCM5sJfI/wLKIZh9e7eyBvzvv4tkMkGZxzsoJARIa+WNs17iB8NtANnAvcBfw+XkUNdo9tq+S0abnkZgW6v1xEholYgyDT3VcD5u5l7v4N4NL4lTV4VTd3sLWiUZPMiciwEWtncUdkttBdZnYD4cnjep1aYrhbt7sWgKVFeQmuRESkf8R6RnAj4XmGPgecBnwIuCZeRQ1ma/fUkpGaxIJJOYkuRUSkX7zhGUHk4rEPuPuXgGbgurhXNYit3V3L4im5pKVo2KiIDA9v+Gnm7j3AWweglkGvsb2LbRWNLNFFZCIyjMTaR7DRzFYB9wEth1e6+1/iUtUgtaGsjpCjIBCRYSXWIMgAaoDzotY5EKggWLe7lpQkY/HU0W+8sYjIEBHrlcWB7hc4bO3uWuZPymFEWqz5KSIy+MV6ZfEdhM8AjuLuH+33igap9q4eNpc3cO1ZhYkuRUSkX8X61fbBqN8zgHcDB/q/nMHrpX31dPaEWFKo/gERGV5ibRr6c/Symd0DrIlLRYPU2siFZMWFuQmuRESkf73ZwfAzgUDNsbB2Ty2zx2czeoTmFxKR4SXWPoImju4jOEj4HgWB0N0T4sWyOt5z6uRElyIi0u9ibRrKjnchg9mOQ020dPaoWUhEhqWYmobM7N1mlhO1PNrM3hW/sgaXzeUNACycrOsHRGT4ibWP4Ovu3nB4wd3rga/Hp6TBZ3N5PTmZqUzLG5HoUkRE+l2sQdDbdoG5qmrTvgZOmZyDmSW6FBGRfhdrEKw3sx+b2UmRnx8DG+JZ2GDR1tnDzkNNahYSkWEr1iD4LNAJ/AlYCbQDn4lXUYPJ1ooGekLOKZN1/wERGZ5iHTXUAtwU51oGpU37wl0ji6bojEBEhqdYRw09amajo5ZzzeyR+JU1eGwur2f8qAzGjcpIdCkiInERa9PQ2MhIIQDcvY4Yriw2s2VmtsPMSszsuDMKM/ukmb1sZpvMbI2ZzY299IHx0r56NQuJyLAWaxCEzGzq4QUzK6SX2UijRW5xeQtwMTAXuKqXD/o/uvsCd18E/BD4cYz1DIiG1i721LSyUM1CIjKMxToE9KvAGjP7B2DA24AVb/CcJUCJu5cCmNlK4HJg6+EN3L0xavss3iBcBtrm/eGTII0YEpHhLNbO4ofNrJjwh/9G4K9A2xs8bRKwL2q5HFh67EZm9hngC0AaR98BLXqbFZH3ZurUqb1tEhcv7QsHwQI1DYnIMBZrZ/H1wGrgi8CXgLuBb/RHAe5+i7ufRHgSu//Txza3unuxuxfn5+f3x9vG5KXyBqaPzSInM3XA3lNEZKDF2kdwI3A6UObu5wKLgfrXfwr7gSlRy5Mj6/qyEhhU8xdtLldHsYgMf7EGQbu7twOYWbq7bwdmvcFz1gEzzazIzNKAK4FV0RuY2cyoxUuBXTHWE3eHGts51NjBKeofEJFhLtbO4vLIdQR/BR41szqg7PWe4O7dZnYD8AiQDNzu7lvM7FvAendfBdxgZhcAXUAdcM2b3ZH+tuVA+EIy9Q+IyHAXa2fxuyO/fsPMngBygIdjeN5DwEPHrPta1O83xl7qwNpW0QTA7PGBvhWDiATACc8g6u7/iEchg83WA41MGZNJdoY6ikVkeHuz9ywe9rZVNDJn/KhElyEiEncKgl60dnazu6aFuRMVBCIy/CkIerHjYBPuMGeCgkBEhj8FQS8OdxTPVRCISAAoCHqxtaKB7PQUJudmJroUEZG4UxD0YltFE7MnZOsexSISCAqCY4RCzvaKRjULiUhgKAiOsa+ulZbOHnUUi0hgKAiOsa0ifIsEBYGIBIWC4BhbK5pIMpilqSVEJCAUBMfYeqCRorFZZKQmJ7oUEZEBoSA4xraKRuZO1IyjIhIcCoIoDW1d7K9vY84ENQuJSHAoCKLsOBi+olgdxSISJAqCKDsOhYNgVoHOCEQkOBQEUXYdaiI7PYUJORmJLkVEZMAoCKLsONjEzIKRmlpCRAJFQRBlV2UzJ6tZSEQCRkEQUd3cQW1LJzMVBCISMAqCiJ2RjuKTC0YmuBIRkYGlIIjYeVAjhkQkmBQEETsrm8nJTCU/Oz3RpYiIDCgFQcSuQ02crBFDIhJACgLA3dl5SCOGRCSYFARAZVMHDW1dCgIRCSQFAa+NGJqpEUMiEkAKAmDnoWYAnRGISCDFNQjMbJmZ7TCzEjO7qZfHv2BmW81ss5mtNrNp8aynLzsPNpGXlcbYkRoxJCLBE7cgMLNk4BbgYmAucJWZzT1ms41AsbufAtwP/DBe9byenZVNahYSkcCK5xnBEqDE3UvdvRNYCVwevYG7P+HurZHF54HJcaynV+5OiUYMiUiAxTMIJgH7opbLI+v68jHg73Gsp1cVDe00dXRrjiERCayURBcAYGYfAoqBt/fx+ApgBcDUqVP79b2PzDE0Tk1DIhJM8Twj2A9MiVqeHFl3FDO7APgqsNzdO3p7IXe/1d2L3b04Pz+/X4ssrWoBYIaCQEQCKp5BsA6YaWZFZpYGXAmsit7AzBYDvyYcApVxrKVPpdXNjMpIYUxWWiLeXkQk4eIWBO7eDdwAPAJsA+519y1m9i0zWx7Z7GZgJHCfmW0ys1V9vFzc7K5uYXq+5hgSkeCKax+Buz8EPHTMuq9F/X5BPN8/FqVVLZw5PS/RZYiIJEygryxu7eymoqGdorFZiS5FRCRhAh0Ee6rDlzBMz1dHsYgEV6CDoLQ6PMeQzghEJMgCHQS7I0NHFQQiEmSBDoLS6hYm5mSQmZac6FJERBIm8EFQlK+zAREJtsAGgbuzu6qZ6WPVUSwiwRbYIKhp6aSxvVv9AyISeIENgt3V4Y7i6WoaEpGAC2wQlFaFh46qaUhEgi64QVDdQlpyEpNyMxNdiohIQgU2CHZXtTAtbwTJSZpsTkSCLbBBUFrdoo5iERECGgQ9IaesRtcQiIhAQIOgvK6Vrh7nJHUUi4gEMwhKI0NHdUYgIhLQINBkcyIirwlkEJTVtJCdnkKe7lMsIhLMINhT08q0sSN0n2IREQIaBGU1LUzLU7OQiAgEMAi6ekLsq2ujMG9EoksRERkUAhcE++va6Ak5hTojEBEBAhgEe2rCI4YKNWJIRAQIYBCU1bQCME1NQyIiQACDYHd1C1lpyeSPTE90KSIig0LgguDwiCENHRURCQtgELRSOFbNQiIihwUqCLp7QuytbdWIIRGRKCsiPM4AAAdYSURBVIEKggP17XRr6KiIyFHiGgRmtszMdphZiZnd1MvjZ5vZi2bWbWZXxLMWeG3oqEYMiYi8Jm5BYGbJwC3AxcBc4Cozm3vMZnuBa4E/xquOaGW6hkBE5DgpcXztJUCJu5cCmNlK4HJg6+EN3H1P5LFQHOs4Ynd1K5mpyYzL1tBREZHD4tk0NAnYF7VcHll3wsxshZmtN7P1VVVVb7qg8NBRzToqIhJtSHQWu/ut7l7s7sX5+flv+nX21LSoo1hE5BjxDIL9wJSo5cmRdQnRE3L21bapf0BE5BjxDIJ1wEwzKzKzNOBKYFUc3+91Hahvo7MnpOmnRUSOEbcgcPdu4AbgEWAbcK+7bzGzb5nZcgAzO93MyoH3Ab82sy3xque1yeZ0RiAiEi2eo4Zw94eAh45Z97Wo39cRbjKKu9emn9YZgYhItCHRWdwfxmWnc+HcAgqyMxJdiojIoBLXM4LB5B3zxvOOeeMTXYaIyKATmDMCERHpnYJARCTgFAQiIgGnIBARCTgFgYhIwCkIREQCTkEgIhJwCgIRkYAzd090DSfEzKqAsjf59LFAdT+WM1QEcb+DuM8QzP0O4j7Die/3NHfvdR7/IRcE/wwzW+/uxYmuY6AFcb+DuM8QzP0O4j5D/+63moZERAJOQSAiEnBBC4JbE11AggRxv4O4zxDM/Q7iPkM/7neg+ghEROR4QTsjEBGRYygIREQCLjBBYGbLzGyHmZWY2U2JricezGyKmT1hZlvNbIuZ3RhZP8bMHjWzXZH/5ia61v5mZslmttHMHowsF5nZC5Hj/SczS0t0jf3NzEab2f1mtt3MtpnZmQE51v8S+ff9ipndY2YZw+14m9ntZlZpZq9Erev12FrYzyL7vtnMTj3R9wtEEJhZMnALcDEwF7jKzOYmtqq46Aa+6O5zgTOAz0T28yZgtbvPBFZHloebG4FtUcs/AH7i7jOAOuBjCakqvn4KPOzus4GFhPd/WB9rM5sEfA4odvf5QDJwJcPveP8OWHbMur6O7cXAzMjPCuCXJ/pmgQgCYAlQ4u6l7t4JrAQuT3BN/c7dK9z9xcjvTYQ/GCYR3tc7I5vdCbwrMRXGh5lNBi4FbossG3AecH9kk+G4zznA2cBvAdy9093rGebHOiIFyDSzFGAEUMEwO97u/hRQe8zqvo7t5cBdHvY8MNrMJpzI+wUlCCYB+6KWyyPrhi0zKwQWAy8ABe5eEXnoIFCQoLLi5T+BLwOhyHIeUO/u3ZHl4Xi8i4Aq4I5Ik9htZpbFMD/W7r4f+BGwl3AANAAbGP7HG/o+tv/051tQgiBQzGwk8Gfg8+7eGP2Yh8cLD5sxw2b2TqDS3TckupYBlgKcCvzS3RcDLRzTDDTcjjVApF38csJBOBHI4vgmlGGvv49tUIJgPzAlanlyZN2wY2aphEPgD+7+l8jqQ4dPFSP/rUxUfXFwFrDczPYQbvI7j3Db+ehI0wEMz+NdDpS7+wuR5fsJB8NwPtYAFwC73b3K3buAvxD+NzDcjzf0fWz/6c+3oATBOmBmZGRBGuHOpVUJrqnfRdrGfwtsc/cfRz20Crgm8vs1wH8PdG3x4u7/5u6T3b2Q8HF93N2vBp4ArohsNqz2GcDdDwL7zGxWZNX5wFaG8bGO2AucYWYjIv/eD+/3sD7eEX0d21XARyKjh84AGqKakGLj7oH4AS4BdgKvAl9NdD1x2se3Ej5d3AxsivxcQrjNfDWwC3gMGJPoWuO0/+cAD0Z+nw6sBUqA+4D0RNcXh/1dBKyPHO+/ArlBONbAN4HtwCvA3UD6cDvewD2E+0C6CJ/9fayvYwsY4VGRrwIvEx5RdULvpykmREQCLihNQyIi0gcFgYhIwCkIREQCTkEgIhJwCgIRkYBTEIhEmFmPmW2K+um3CdvMrDB6JkmRwSTljTcRCYw2d1+U6CJEBprOCETegJntMbMfmtnLZrbWzGZE1hea2eOROeBXm9nUyPoCM3vAzF6K/Lwl8lLJZvabyFz6/2tmmZHtPxe5h8RmM1uZoN2UAFMQiLwm85imoQ9EPdbg7guA/yI82ynAz4E73f0U4A/AzyLrfwb8w90XEp7/Z0tk/UzgFnefB9QD742svwlYHHmdT8Zr50T6oiuLRSLMrNndR/ayfg9wnruXRib1O+jueWZWDUxw967I+gp3H2tmVcBkd++Ieo1C4FEP31QEM/sKkOru3zGzh4FmwtNE/NXdm+O8qyJH0RmBSGy8j99PREfU7z281kd3KeG5Yk4F1kXNoikyIBQEIrH5QNR/n4v8/izhGU8Brgaejvy+GvgUHLmXck5fL2pmScAUd38C+AqQAxx3ViIST/rmIfKaTDPbFLX8sLsfHkKaa2abCX+rvyqy7rOE7xD2r4TvFnZdZP2NwK1m9jHC3/w/RXgmyd4kA7+PhIUBP/PwLSdFBoz6CETeQKSPoNjdqxNdi0g8qGlIRCTgdEYgIhJwOiMQEQk4BYGISMApCEREAk5BICIScAoCEZGA+//t51sUeflK2AAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light",
+            "tags": []
+          },
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAEGCAYAAABvtY4XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3de3hcd33n8fd3NLqNNBrrLtmyLTu+O7GT2HGcC2kukIaQQrmVW2kJPJstS1vYUtrQy+7TpV3odjel2bKUEAgp0FJKgIYQQu4kLUlsOTffHduxbMvWxZJ1v4703T9mLMuJ7Ci2jkc683k9jx5rjkZzvkdH/ujM9/zO75i7IyIi4RPJdAEiIhIMBbyISEgp4EVEQkoBLyISUgp4EZGQima6gIkqKiq8vr4+02WIiMwaW7ZsOebulZN9bUYFfH19PQ0NDZkuQ0Rk1jCzxtN9TS0aEZGQUsCLiISUAl5EJKQU8CIiIaWAFxEJqUAD3szmmNkPzGyXme00syuCXJ+IiJwU9DDJvwMecvf3mVkeEAt4fSIikhbYEbyZJYBrgG8AuPuwu3dO93rcnTsfe4Wn9rRN90uLiMxqQbZoFgFtwD1m9oKZ3W1mRdO9EjPjrqf28+RuBbyIyERBBnwUuBT4qrtfAvQBt7/2SWZ2m5k1mFlDW9vZhXSiMJfOgeFzKlZEJGyCDPjDwGF3fy79+AekAv8U7n6Xu6939/WVlZNOp/CGEoW5dA+MnH2lIiIhFFjAu3szcMjMlqcX3QDsCGJdc2K5dPYr4EVEJgp6FM3vAd9Nj6DZD9waxEoShbnsbe0N4qVFRGatQAPe3V8E1ge5DkgfwatFIyJyilBcyVpSmEtX/wjunulSRERmjFAE/JzCPIZHxxgcGct0KSIiM0Y4Aj6WC6ChkiIiE4Qi4BOFqYDvUh9eRGRcKAJ+TjrgNVRSROSkUAR8iY7gRUReJxQBf6IH36UjeBGRcaEIePXgRUReLxQBX5wfJSdiGkUjIjJBKALezEgU5uoIXkRkglAEPKRG0mgUjYjISaEJ+ERMR/AiIhOFJ+DVohEROUVoAl4tGhGRU4Um4HUELyJyqvAEfCyP7sERxsY0ZbCICIQp4AtzcYeewWSmSxERmRFCE/DjE47pYicRESBMAR/TdAUiIhOFJuATmjJYROQUoQl4HcGLiJwqNAFfMt6DV8CLiECIAn58yuB+nWQVEYEQBXx+NIfC3By1aERE0kIT8JDqw+skq4hISqgCXtMViIicFLqA10lWEZGUUAX8nFgu3Qp4EREgZAGf0JTBIiLjQhXwc2J56sGLiKSFKuAThbkMjIwyODKa6VJERDIudAEPqA8vIkJIA15tGhGRkAX8iQnHNFRSRCRsAV+YB0CXRtKIiIQr4BOaUVJEZFw0yBc3swNADzAKJN19fZDrS2hOeBGRcYEGfNp17n7sPKyHeH4UM00ZLCICIWvRRCKmCcdERNKCDngHHjazLWZ222RPMLPbzKzBzBra2trOeYVlsTyO9ekIXkQk6IC/2t0vBd4OfMrMrnntE9z9Lndf7+7rKysrz3mFFfF82nqGzvl1RERmu0AD3t2b0v+2Aj8CNgS5PoAqBbyICBBgwJtZkZnFT3wO3AhsC2p9J1TFC2jtHgx6NSIiM16Qo2iqgR+Z2Yn1/JO7PxTg+gCojOfTNzxK31CSovzzMUhIRGRmCiwB3X0/sDao1z+dqng+AG09Qwp4EclqoRomCVBVkgr4VvXhRSTLhS/g4wUAtPaoDy8i2S10AV85oUUjIpLNQhfwpbFccnNMLRoRyXqhC3gzo7I4n9ZuBbyIZLfQBTyk2jTqwYtItgtpwBeoBy8iWS+UAV9VoukKRETCGfDxfNr7hhkZHct0KSIiGRPKgD8xVPJYr47iRSR7hTLgT1zspDaNiGSzkAZ8eroCDZUUkSwWyoA/0aLRxU4iks1CGfAVxScCXmPhRSR7hTLg86IRyory1IMXkawWyoCHVB9eLRoRyWahDfhKBbyIZLlQB3yb7s0qIlkstAFfFS+grXcId890KSIiGRHagK+M5zMy6nT2j2S6FBGRjAhtwFdpLLyIZLksCHj14UUkO4U34Es0H42IZLfQBrymKxCRbBfagC/OjxLLy9GEYyKStUIb8HDialb14EUkO4U64GsThTR1DmS6DBGRjAh1wC8sj3GwvT/TZYiIZESoA35BeYz2vmF6h5KZLkVE5LwLdcAvLCsCoLG9L8OViIicf+EO+PIYgNo0IpKVQh3wC9IB39ihgBeR7BPqgC8pyKU0lkujjuBFJAuFOuABFpQXcbBDPXgRyT6hD/iFZTEdwYtIVgo84M0sx8xeMLMHgl7XZBaWxzjSOcBwciwTqxcRyZjzcQT/aWDneVjPpBaUxRhzdEWriGSdQAPezOqAdwB3B7meM1lYrrHwIpKdgj6C/zLwR8Bp+yNmdpuZNZhZQ1tb27QXMD4WXkMlRSTLBBbwZnYL0OruW870PHe/y93Xu/v6ysrKaa+jKp5PQW5EFzuJSNYJ8gj+KuCdZnYA+B5wvZl9J8D1TcrMWFAW08VOIpJ1Agt4d/+8u9e5ez3wQeBxd//NoNZ3JgvKinQELyJZZ0oBb2afNrMSS/mGmT1vZjcGXdx0WVge42BHP+6e6VJERM6bqR7Bf9zdu4EbgVLgo8CXproSd3/S3W85i/qmxcLyGAMjo7oBt4hklakGvKX/vRn4trtvn7BsxltQpknHRCT7TDXgt5jZw6QC/udmFucMQx9nmpNj4RXwIpI9olN83ieAi4H97t5vZmXArcGVNb3mzSkkYnBQFzuJSBaZ6hH8FcBud+80s98E/gzoCq6s6ZUXjTB3TqFaNCKSVaYa8F8F+s1sLfBZYB/wj4FVFYD68iJePaYjeBHJHlMN+KSnxhi+C/h7d/8KEA+urOm3vCbOnpYeRsc0VFJEssNUA77HzD5PanjkT80sAuQGV9b0W1ETZ3BkTJOOiUjWmGrAfwAYIjUevhmoA/4msKoCsLK2BIBdzT0ZrkRE5PyYUsCnQ/27QCI9idigu8+qHvySqmJyIsbOo92ZLkVE5LyY6lQFvwFsAt4P/AbwnJm9L8jCpltBbg6LK4rYeVRH8CKSHaY6Dv5PgcvcvRXAzCqBR4EfBFVYEFbUlvB84/FMlyEicl5MtQcfORHuae1v4ntnjJW1cZo6B+geHMl0KSIigZtqSD9kZj83s4+Z2ceAnwIPBldWMFbWpE607taJVhHJAlM9yfo54C5gTfrjLnf/4yALC8KK2tTQfZ1oFZFsMNUePO5+H3BfgLUErqakgERhrk60ikhWOGPAm1kPMNmlnwa4u5cEUlVAzIyVtXF2NesIXkTC74wB7+6zajqCqVhRU8L3Gw4xNuZEIrNmSnsRkTdt1o2EOVcra+P0D49yUDNLikjIZWHAn5iyQG0aEQm3rAv4pVVxIgY7dKJVREIu6wK+MC+H+ooidmmopIiEXNYFPMCq2hK2Nc2aG1KJiJyVrAz4dQtLOdI1SFPnQKZLEREJTFYG/GX1ZQBsfrUjw5WIiAQnKwN+ZW0J8fwomw4o4EUkvLIy4HMixqULS2lQwItIiGVlwANsWFTGnpZejvcNZ7oUEZFAZG3An+jDN+gGICISUlkb8GvqEuTlRNisNo2IhFTWBnxBbg5r6hJs0kgaEQmprA14gMsWlbGtqYv+4WSmSxERmXZZHfAb6stIjjkvHuzMdCkiItMuqwP+0oWlmMHmAzrRKiLhk9UBnyjMZUVNiU60ikgoZXXAA1y+qIyGxg4GR0YzXYqIyLTK+oC/dnklgyNjPLO/PdOliIhMq8AC3swKzGyTmb1kZtvN7C+CWte52Li4nFheDo/vbM10KSIi0yrII/gh4Hp3XwtcDNxkZhsDXN9ZKcjN4eolFTy+qxV3z3Q5IiLTJrCA95Te9MPc9MeMTNAbVlbR1DnA7hbdxk9EwiPQHryZ5ZjZi0Ar8Ii7PzfJc24zswYza2hrawuynNO6bnkVAI+pTSMiIRJowLv7qLtfDNQBG8zswkmec5e7r3f39ZWVlUGWc1pVJQWsqUvw2M6WjKxfRCQI52UUjbt3Ak8AN52P9Z2N61dU8cKhTtp7hzJdiojItAhyFE2lmc1Jf14IvA3YFdT6ztUNK6pxhyd3Z6ZNJCIy3YI8gq8FnjCzl4HNpHrwDwS4vnOyem4JVfF8Ht+lPryIhEM0qBd295eBS4J6/ekWiRg3rKziJy8dZXBklILcnEyXJCJyTrL+StaJfm3tXHqHkjy49WimSxEROWcK+AmuWFxOfXmM7206lOlSRETOmQJ+AjPjA5ctYNOBDva29r7xN4iIzGAK+Nd437o6ohHjXzYfzHQpIiLnRAH/GpXxfN66spr7nm9iKKkphEVk9lLAT+KDG+bT0TfMIzt0ZauIzF4K+Em8ZWkl8+YU6mSriMxqCvhJ5ESMD1w2n3/fe4x9bTrZKiKzkwL+ND58+QLyoxHufnp/pksRETkrCvjTqCjO573r6rjv+SbaejQBmYjMPgr4M/hPb1nMyOgY9/7yQKZLERF50xTwZ7CooogbV1Xz7Wcb6RtKZrocEZE3RQH/Bm675gK6Bkb4foNG1IjI7KKAfwPrFpayfmEpdz/9KiOjY5kuR0RkyhTwU/Cp65bQ1DnA3U+/mulSRESmTAE/BdetqOKm1TX87aN72K9x8SIySyjgp+h/vGs1BdEIt9+3lbExz3Q5IiJvSAE/RVUlBfzZLavYdKCDf9qkmSZFZOZTwL8J719Xx9VLKvjSz3ZxtGsg0+WIiJyRAv5NMDO++J6LSI6N8ec/3o67WjUiMnMp4N+k+WUx/uBty3h0ZwsPbWvOdDkiIqelgD8LH79qEavnlvDf7t9O18BIpssREZmUAv4sRHMifOk9a2jvHeJLP9uV6XJERCalgD9LF9Ul+PhVi/jnTQd5YldrpssREXkdBfw5+IMbl7GqtoRP/dPzbGvqynQ5IiKnUMCfg1helHtuvYzSWB63fmszh4/3Z7okEZFxCvhzVF1SwD23XsbgyCi33rOZrn6ddBWRmUEBPw2WVcf52kfX0djez0e+8SzH+4YzXZKIiAJ+ulx5QQVf++g69rT08uG7n6O9V7f5E5HMUsBPo+tWVHH3b61nf1svH/76c7R2D2a6JBHJYgr4aXbNskru+dhlHOzo5+Y7n+YXe9oyXZKIZCkFfACuXFLBv/3uVZQV5fHb39zEFx/cyXBSd4MSkfNLAR+QZdVx7v/dq/nI5Qv42lP7+fi3NuvG3SJyXingA1SQm8Nfvfsi/uZ9a3hmfzsfvvs5jbARkfNGAX8evH/9fP7hN9ex82g37//aMzR1ai55EQleYAFvZvPN7Akz22Fm283s00GtazZ426pqvv3xDbR0DfL2Lz/Fj19o0nzyIhKoII/gk8Bn3X0VsBH4lJmtCnB9M97li8v5ye9dzdLqOJ/5lxf55Heep61H4+VFJBiBBby7H3X359Of9wA7gXlBrW+2qK8o4vv/+Qpuf/sKHt/VyrV/8wR3PLKH7kFNcSAi08vOR5vAzOqBp4AL3b37NV+7DbgNYMGCBesaGxsDr2em2Nvayx2P7ObBrc3MieXy0Y0LuenCGlbVlmBmmS5PRGYBM9vi7usn/VrQAW9mxcAvgL9y9x+e6bnr16/3hoaGQOuZibY1dfF/Ht7Nk3vacIf5ZYV8YP18brvmAvKiOg8uIqeXsYA3s1zgAeDn7n7HGz0/WwP+hGO9Qzy6o4Wfbj3K068cY/XcEu74jYtZXhPPdGkiMkNlJOAt1WO4F+hw989M5XuyPeAn+vn2Zv7kh1vpGUzyX667gN+6op6yorxMlyUiM0ymAv5q4GlgK3DiOv0/cfcHT/c9CvhTHesd4s9/vI2fbWsmLxrhljW1vG9dHatrEyRiuZkuT0RmgIz24N8MBfzk9rT08O1nGvnh84fpGx4FoLokn1W1JWxcXM6VF1Swam4JORGdmBXJNgr4kOgdSrL51Q72tPSwu6WHrYe7eKW1F4DSWC43rqrhHWtqueKCcnJzdHJWJBso4EOstXuQZ/a388SuVh7d2UrvUJI5sVyuW17F9SuquGZZJYlCtXNEwkoBnyUGR0Z5ak8bP9vWzJO7WzneP0I0Yrx1ZTUf3DCftyytJGJwpGuQg+39LK+J68StyCx3poCPnu9iJDgFuTncuLqGG1fXMDrmvHjoOD/b2swPX2jioe3NVBTnMzCcHO/jRwzWLyzjbauqeduqauorijK8BSIynXQEnwWGkqM8sqOFh7e3UFaUx5KqYuaVFvJC43Ee3tHCruYeAJZUFfPWldXMLysc/96B4VG6B5P0DI6wcXE5v7q6JlObISKTUItGzuhQRz+P7mzh0Z0tPLe/g+TY638n8qMRhpJjfPLaC/jcjcuJaMSOyIygFo2c0fyyGLdetYhbr1pE31By/M5TTqrtU5wfZXTM+e/3b+erT+5jb2svf/3eNeREjOToGG29Q+xu7mFXcw/DyTGuvKCcjYvLKcrXr5dIJukIXqbM3fnWLw/whQd2MMlBPtGIEYkYw8kxcnOMlbUlJApziRdESRTmUlcaY35ZjNpEAREDdxgZdVp7BmnuGqSjf5gLKopZMz/B0qr4Gcf1uzv9w6PE8nI0MZtkNR3By7QwM269ahFr6hJsPnCc3JwIuTlGojCX5TVxFlcUM+bOlsbjPP3KMbYf6aJ3KElz1yDH+4c51nvm2xVGIzbeHorl5bBuYSlXLalgw6IymrsGaThwnBcOHedo5yAdfcMMj45xQWURv/MrF/Drl8w749j/PS09fOGBHRzs6Of96+r40IYFlBfnT3nbB4ZH2XG0mzV1ibO6xmBwZJT8aER/jOS80hG8nDf9w0kOHx+guWsQB4xUqFeV5FNdUkBRXpRX2/t4+XAnLxzs5Jl97eMXckHqPMDa+XOoL49RWpRHPD/KT7c2s/NoN3MTBVy9tIK8aIS8nBwShbnMKy1kbqKAR3e2cu8zByjOj7KyNs6z+zvIy4lwy9paPnZlPWvq5gCpdwXbmrppaOygNJZHVTwfB+5/8Qg/3XqU3qEkK2ri/NW7L2TdwrJJt9Hd2d3Sw8PbW3h8VytNnQN0DYwwnBxjWXUxn3nrMm5aXUMkYoyNOTuOdrO1qYu9rb3sbe0lJ2Jcu7yS61dUUVcaYyg5Smv3EMOjYywsixHN4AVs/cNJ3Alt6y05Opaxn6+7n/Uff51klVmrpXuQLY3HqU0UsHpu4nXTJ7s7T+5p4+tP7Wd/Wx/Do2MMJ8foTZ9HADCDD21YwB/euJyyojz2tvbyj88c4L4tqakfLlkwhw2Lynhkewv7j/W9roZYXg7vuKiWtfPn8P+e2MuRrkHec+k8akoKaO4epK1niO6BEXqHknQNjIy/U7l4/hxW1MRJFOZSmJfDT146wr62PlbUxFlcWcQz+9o53p+60Ut+NMLiymIGhpMcaO8HoKQgSvfgye3Ii0ZYVl3MypoSLpyX4MJ5CZbXxClKt6nGxpymzgH2tPRw+PgAly4o5cJ5J+8tcLxvmGf3t1NcEGVpVZzqkvwphUpjex/3/McB/rXhEGbGH964jI9eUX/GFlr/cJIvP/oKD249yud+dTnvXDs30HcvQ8lRvv7Ufva29nLhvAQXzUuwrDrOnFjuG6738PF+/ueDO/nZtmZW1ZZwzbJK3rK0gpU1JZSmrxMZHBnl+YPH2dbUxVuWVrKytuS0rzc4Msrx/mEGR8YYSo6SKMylpqRg0jp6h5J87Rf72NbUxTc/dtlZ/YwU8JJ1BkdGae4apKlzgOqSApZUFb/uOd2DI9y35TD3/vIAjR39XL6ojF+/eB7XLq+idyhJW88QAyNJLl908oRx31CSv3vsFb75768CUBXPp7KkgERhLsX5qRPSF88v5a0rq6gqKThlfaNjzk9eOsJXnthL31CSKy6o4Oql5axbUEZdaeH4yKT9bb08trOVgx39VMVT724iEWNPSw87j3az40g37X2ntrvyciJgMJwcO2X5vDmFXLOskj0tPbxw8Pgp507i+VEWVxWzpLJ4fOhsRXEelcX5HO0apOFAB8+92sGmAx1EI8avrZnLsb5hntrTxtq6BB+/ehGt3UMc7OhncGSUNXUJLllQmpok79+2cahjgIXlMRrb+7lpdQ1/+e4LKYvl0TkwQt9QkrrSwlMCbWB4lJ+8dAQzqE0UUhHPY3dzD8/sa2fTqx3E8nNYXZtg9bwSLpqXYNXcEvKjOWxr6uKz33+J3S09VBTnc6z35G0w86IRquL5LCyPcVl9GRsXl7O8Ok734AjtfcP8Yncb//CLfZjBey6tY29rL883Hh9vFZYV5VFTUsDe1l6GR0/+bG9aXcPv37CUVXNPBv3Oo91859lGfvRCE/3pa03Gf9YFUZZWFbOyNlX7hfMSvHy4izse2cOx3iHeuXYuf/3eNRTm5ZzmN/r0FPAiZzA25vQNJ4kXTH1Kh8GRUfJyIhkZLuruNHcPsq2pm72tvQyOjDKUHMPdqa8oYll1nJpEAb/ce4yHtjXzH/uOsbQqPj51xVBylH2tvbySbgvtbe2ldZJ7A0cMVs0t4frlVXxk40KqSwpwd+5/6QhfeGDH+DuVkoIouTmRU/7oLK4s4ovvvoj19WV8/en93PHwHsxSf+ROhOfK2hJuvaqemy+q5UfPH+bOx/dOeo/ieEGUyxeVMZQcY1tT1/i7nrycCMtr4uw42k15UR5ffM9F3LCymraeIbY2dbK/rY+2niFae1KjvHY2dzNZ3N2yppbP37ySeXNS13/0DI7Q0Hicfa297GvrpalzkBU1cTYuLmNZdZzvNxzmnn9/lZ6hJPH8KEX5UfKiEQ529JMfjfBra+eyfmEpBbk55EUjHOsdYk9LD3taetl5tJueCe/KLqsv5U9uXsklC0rP+vdBAS8iZ9Q1MEJL9yDHeoZo6x2irCiPSxaUUnyafnvP4AiN7f3ML42RiOXi7hw+PsCLhzrpG0ry7kvnkR89eTS6p6WH7z7bSFF+dPzcxvc2HWJ3Sw8RgzGHDfVlfPbGZdQkCmjuGqSlZ4j68hir5ybG20HuzpGuQV4+1MmLhzp56XAniyqKuf2mFW84hXZX/wibD3RwoL2PObE8yovymF8Wm/Td3Rv+vPpH+NcthzjSOUjv0Ah9Q6OsnZ/g/evmj7d1JjM25jR29LO1qYuSgii/sqzynFtXCngRmXHcnWf2tfPQ9mauW1HFtdMQdtlIwyRFZMYxM65cUsGVSyoyXUpoadJwEZGQUsCLiISUAl5EJKQU8CIiIaWAFxEJKQW8iEhIKeBFREJKAS8iElIz6kpWM2sDGs/y2yuAY9NYzmyQjdsM2bnd2bjNkJ3b/Wa3eaG7V072hRkV8OfCzBpOd7luWGXjNkN2bnc2bjNk53ZP5zarRSMiElIKeBGRkApTwN+V6QIyIBu3GbJzu7NxmyE7t3vatjk0PXgRETlVmI7gRURkAgW8iEhIzfqAN7ObzGy3me01s9szXU9QzGy+mT1hZjvMbLuZfTq9vMzMHjGzV9L/nv3NHWcoM8sxsxfM7IH040Vm9lx6n/+LmZ3+HmmzlJnNMbMfmNkuM9tpZleEfV+b2X9N/25vM7N/NrOCMO5rM/ummbWa2bYJyybdt5ZyZ3r7XzazS9/MumZ1wJtZDvAV4O3AKuBDZrYqs1UFJgl81t1XARuBT6W39XbgMXdfCjyWfhw2nwZ2Tnj818DfuvsS4DjwiYxUFay/Ax5y9xXAWlLbH9p9bWbzgN8H1rv7hUAO8EHCua+/Bdz0mmWn27dvB5amP24DvvpmVjSrAx7YAOx19/3uPgx8D3hXhmsKhLsfdffn05/3kPoPP4/U9t6bftq9wK9npsJgmFkd8A7g7vRjA64HfpB+Shi3OQFcA3wDwN2H3b2TkO9rUrcQLTSzKBADjhLCfe3uTwEdr1l8un37LuAfPeVZYI6Z1U51XbM94OcBhyY8PpxeFmpmVg9cAjwHVLv70fSXmoHqDJUVlC8DfwSMpR+XA53unkw/DuM+XwS0AfekW1N3m1kRId7X7t4E/G/gIKlg7wK2EP59fcLp9u05ZdxsD/isY2bFwH3AZ9y9e+LXPDXmNTTjXs3sFqDV3bdkupbzLApcCnzV3S8B+nhNOyaE+7qU1NHqImAuUMTr2xhZYTr37WwP+CZg/oTHdelloWRmuaTC/bvu/sP04pYTb9nS/7Zmqr4AXAW808wOkGq/XU+qNz0n/TYewrnPDwOH3f259OMfkAr8MO/rtwKvunubu48APyS1/8O+r0843b49p4yb7QG/GViaPtOeR+qkzP0ZrikQ6d7zN4Cd7n7HhC/dD/x2+vPfBv7tfNcWFHf/vLvXuXs9qX37uLt/BHgCeF/6aaHaZgB3bwYOmdny9KIbgB2EeF+Tas1sNLNY+nf9xDaHel9PcLp9ez/wW+nRNBuBrgmtnDfm7rP6A7gZ2APsA/400/UEuJ1Xk3rb9jLwYvrjZlI96ceAV4BHgbJM1xrQ9l8LPJD+fDGwCdgL/CuQn+n6Atjei4GG9P7+MVAa9n0N/AWwC9gGfBvID+O+Bv6Z1HmGEVLv1j5xun0LGKmRgvuAraRGGU15XZqqQEQkpGZ7i0ZERE5DAS8iElIKeBGRkFLAi4iElAJeRCSkFPASemY2amYvTviYtkm6zKx+4qyAIjNJ9I2fIjLrDbj7xZkuQuR80xG8ZC0zO2Bm/8vMtprZJjNbkl5eb2aPp+fffszMFqSXV5vZj8zspfTHlemXyjGzr6fnMn/YzArTz//99Pz9L5vZ9zK0mZLFFPCSDQpf06L5wISvdbn7RcDfk5q5EuD/Ave6+xrgu8Cd6eV3Ar9w97Wk5obZnl6+FPiKu68GOoH3ppffDlySfp3fCWrjRE5HV7JK6JlZr7sXT7L8AHC9u+9PT+TW7O7lZnYMqHX3kfTyo+5eYWZtQJ27D014jXrgEU/dqAEz+2Mg193/0sweAnpJTTXwY3fvDXhTRU6hI3jJdn6az9+MoQmfj3Ly3NY7SM0jcimwecKsiCLnhQJest0HJvz7TPrzX5KavRLgI8DT6c8fAz4J4/eJTZzuRc0sAu8xcAgAAACSSURBVMx39yeAPwYSwOveRYgESUcUkg0KzezFCY8fcvcTQyVLzexlUkfhH0ov+z1Sd1P6HKk7K92aXv5p4C4z+wSpI/VPkpoVcDI5wHfSfwQMuNNTt90TOW/Ug5esle7Br3f3Y5muRSQIatGIiISUjuBFREJKR/AiIiGlgBcRCSkFvIhISCngRURCSgEvIhJS/x9irFJdhc13LwAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light",
+            "tags": []
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -223,73 +238,54 @@
         "\n",
         "plot_graphs(history, 'accuracy')\n",
         "plot_graphs(history, 'loss')\n"
-      ],
-      "execution_count": 36,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxcdb3/8dcne5qmaZqm6d6ktHSnLYQWRJFVCkhxQQVRAcW6oXjVq9zr7+fuzwWvXvXigggCKhVQvL2IcKGAULYutBS6h7Rp06bNvu+Zz++PmZZpm8AUM5kk5/18PPIg58yZmc/JKfOe8/1+z/eYuyMiIsGVlOgCREQksRQEIiIBpyAQEQk4BYGISMApCEREAi4l0QWcqLFjx3phYWGiyxARGVI2bNhQ7e75vT025IKgsLCQ9evXJ7oMEZEhxczK+npMTUMiIgGnIBARCTgFgYhIwCkIREQCTkEgIhJwCgIRkYBTEIiIBJyCQEQGvXV7aln10gFCIU2bHw9xvaDMzJYBPwWSgdvc/fu9bPN+4BuAAy+5+wfjWZOIJJa7s+VAI9PyRpCdkXrUYzXNHQDkjUwHIBRyfvFkCT9+dCchhzuf3cN33jWfORNGxfReDa1d/O/Wg2wub+DzF8w88roDpb2rhzW7qtl+sJEdh5oB+L/vnMO47IyYn5+RmhzPEoE4BoGZJQO3ABcC5cA6M1vl7lujtpkJ/BtwlrvXmdm4eNUjIn3bfrCRioZ2zp6ZT3KSHfVYR3cPe2taKa1uoaymhQP17eyvb6O5vZszpufxjnkFzB6fjdnRz6tsauf7D21nRHoyCyePZvb4UTz7ajV/Wr+P0qoW5kwYxT0fX8roEWkA7DzUxFW3Pk9daydnzRjLO0+ZwN9fOciTO6p416KJnHlSHj94eAfv/Pka3l88mWXzJ7C0aMxxH5TuzpqSam5fs5s1JdV09YTPIrZWNPKH65e+4Qfr7uoWfv74Ljq6QowblU7BqAwuXTCBKWNG9Pmc9q4ekpOM1OTXGlk6unu45va1vLC7FoDJuZnUNHfyYlkdd1x3OicXZB/3Oh3dPTyxvYo1JVU8W1JDaXULly+ayDeXzzvyd4oHi9cdyszsTOAb7n5RZPnfANz9e1Hb/BDY6e63xfq6xcXFrikmRE6Mu9PY3k1tSyejMlKOfDNu7ezmJ4/u5LdrdhNymDFuJJ87fyZvOSmPR7YcZNWmA6zbU0t0i8zI9BQmjc4kNcXYcqARd5iWN4Kbls3m4gUTADhQ38bVt73Agfo20pKTaOroPvL84mm5vG1mPrc8UcKcCdncff1SKhvbufLW50ky472nTeahlysoq2klLTmJr102l6uXTsXMqG/t5OZHdnD/hnI6ukNkpCaxtCiP4mm5nDotF4CfPraLtXtqKRiVzrsWTeKSBRMor2vjM398keULJ/LTKxdhZrg7JZXNpCYnMTY7/Pf4r8dL+O2aUtKSkyjIyaCysYPmjm7Gjkxn5YozmDFu5FF/0xf31nHvunIe3HyAzLRkbvngqSydnkco5PzLvZv4700H+O6757N84USyM1J5ubyBj965jvauHn565SLmTcwhJcmoaenk3nX7+POL5dS1djEiLZkzpucxcXQGK9fuIzcrje+/ZwHnzyl40/8GzGyDuxf3+lgcg+AKYJm7Xx9Z/jCw1N1viNrmr8BO4CzCzUffcPeHe3mtFcAKgKlTp55WVtbnlBkicdHe1cMdz+xh8dTRnDE9L+7v9+SOSn748A5uOG8Gl0Q+XGPh7rR3hWjq6GLT3nrWlFTzTEk1e2tbj3wzBijMG8GpU3NZV1bLvto2rloylaVFY7jliRJ2VTYf2e6k/CwumjeeWeOzKRqbxbS8LHIyX2vOqWrqYPW2Q9z1XBlbKxq5dMEEPva2Ij77x400tnXxu4+ezuIpuZRWt7C1opG5E0Yd+TB9bOshPvn7DcyflMP++jYAVq44g5PyR+LuvLK/kVGZKUzLyzpuP9u7eniutIZ/7KjimZLqo2oel53OZ86dwZVLppCe8tq3/1ueKOHmR3bwibdPJ3dEGvdGzkwOSzIIOVxx2mS+vGzWkeabnYea+OBvwiH1p0+cSdHYLJ7eVcX3/76dLQcaGZGWzKULJrChrI69ta189dI5VDV18IsnX+VfL5rFZ86dcVTt++vbuO6Otew81HzU+pQk4x3zCvjA6VM5c3oeaSnhs4stBxr44r0vsf1gE9+4bC7XnlUU47+Gow3mIHgQ6ALeD0wGngIWuHt9X6+rMwL5Zx1uo36+tIb01GRyMlMpyE7n9MIxJB3TLAKw42ATN67cyPaDTSQZfOHCk/n0OTN63faw5o5ufvTIDp4pqabHnVDIyUhNZlreCArHZjF3wigumFNAVvrxrbNP7qhkxd0bAOjsDvG+0ybz9eXzGBm1bVN7F3c9V8bvnt1DQ1sXBphBR3eI6P+lM1OTWTp9DLPHjyIvK40xWWlUNXewoayOjXvrGJOVxrcvn8/SSLiFQs5Dr1RQUtnMhXMLmDth1HFNPr3p6glx61Ol/PSxXXT2hBg9IpW7P7qUBZNzXvd5D71cwQ1/fJExWemsXLGUGeOOby6JRUNbF5v21VPb0sHF8yf02vzj7nzpvs38+cVyAE4vzOVdiyeRkZJMdXMHda1dXDSvgMVTc4977s5DTVx56/OkJScxs2AkT++qZnJuJjecO4PLFk4kKz2FxvYuvvCnTTy2rRKAq5ZM4f+9e0Gvf7+m9i4e3XqItq4eunuc1OQkLpxbQH52730Ynd0hfvnkq1y5ZAoFo2LrXzhWooIglqahXwEvuPsdkeXVwE3uvq6v11UQSG/au3ro6gkd1/kYrb61k1/9o5SHXq5gb23rcY9//G1FfPXSuUeW3Z3fv7CX7zy4leyMFL59+Xz+/spBVr10gHNm5XP+nAJeLKvjxb115I5I472nTWb5KRN5eX8DX/nzZg40tHHurHFkpiWTbEZLRzd7alrYV9tGZ0+IEWnJXDx/ApctnMCcCaMYl53OU7uq+fhd65mRP5I7P7qEO5/dwy1PljBpdCZLCscwJivcTnzfhnIa2ro4Z1Y+s8ePwnHcIT0liaz0FLLSkpkxLptTp40+6ltxvO081MTta3Zz3VlFzBof24f6xr11jBuVwaTRmXGuLvyB+teN+ykuzGV6/sg3fkKUbRWNfPA3zxNy+Ox5M/jwmdOO+9uGQs6vnyqlvK6Vby6fR0ry4BmYmaggSCHc7HM+sB9YB3zQ3bdEbbMMuMrdrzGzscBGYJG71/T1ugoCiVbT3MHdz5dx93NlNHV08+WLZvHRs4qO+7ZeVtPCdb9bR1lNK2fNGMsl88dz3pzw2ISG1i5uf2Y396zdx08+sJB3L56Mu/ODh3fwq3+8yjmz8rn5ioXkZ6cfCYdv/89WOntC5Genc+rU0ZTVtLL9YBNpyUl09oSYnp/FzVecwmnTxhxXc08o3Lb85w3lPLi5guZI+3lWWjKdPSFmjsvmD9cvJTfyof9CaQ0/+t8dHKhvp6alg/auEBfMGcfnzp/JKZNHx/kvLNFqWzpJTbbX/cIxWCUkCCJvfAnwn4Tb/2939++a2beA9e6+ysLnTP8BLAN6gO+6+8rXe00FQbC0dHRTUtnMpNxMxkYN/XN3fvHkq/xs9S46ukOcN3scBqzeXsnSojHcfMVCpozJxMx4cW8d19+5npA7t364mCVFx384d/WE+NBtL7BxXz33fuJM/ryhnLufL+PqpVP59uXzjwuWioY2urr9yHscbm56YON+RmWk8om3T49p2F9bZw8byuoorW6mtKqFrp4QX3rHrCMh0JuuntBRo1NEYpGwIIgHBcHwVtvSyRPbK3l8eyUvlddTXhfuRMzOSOHmKxaybP54QiHnWw9u5XfP7uGSBeP5woUnM2NcNu7OfRvK+db/bKW5o5uM1CTystKpau5gQk4Gd1x7+us2B9Q0d7D8v56hsqmdrh7nE2dP56aLZ8fURi4y2CkIJGHau3rYW9vKwYZ2FkzK6fWbbkVDGw+/cpC/v3KQ9ZGhiuOy01lSNIZZBdkUjs3iN0+Xsrm8gevfWkRNSycPbNzPx99WxL9fMue4D+ryulYeermC6uZOqps7SE9J4kvvmBXTxURbDzRy7R1r+ciZ0/jMuTMUAjJsKAhkwL1a1cyKu9ZTWt1yZBRLcpLxlpPyuGjeeNq7ethxsImtFY1sOdAIwKyCbN4xr4AL5xYwf2LOUc0xHd09fPdv27jrufDQ4X+9aBafPuekuHxQu7sCQIYdBYEMqJ6Q875fPUtpdQvXvaWIwrEjyMtKZ01J9VEjdsaOTOfkgpGcNWMsy+aP56QYRnE8tvUQnT2hExpbLyKvHwRD7ub1Mvj97tk9vLi3nv/8wCLetXjSkfVvnTmWryybRWl1C6MzU9/UvC8XzH3zV1aKSO8UBHLCDja08/j2SmYWjGT+xBwy014bHVNW08LNj2zn/NnjuHzRxOOea2YxffMXkYGjIJAT8mpVMx++7QUONLQD4Xb/2eOzOWXyaE6ZnMMDG/eTmpTEd/u4olJEBh8FgcRsy4EGPvLbtZjBPR8/g5aObjbtq2fTvnr+tvkA96zdC8D33rOA8Tlv7jJ4ERl4CgI5yr7aVl6taub0wjFH5sFpaOvi4Vcq+M7ftpGdnsLvr196ZDz+4TZ7d6esppWDje0s7eWCLREZvBQEcsSGslquvWMdTe3dpCUncXpRLiPSUvjHjio6e0LMHp/Nb689vdc5YcyMwrFZFI49fqZIERncFAQCwJrIZGfjczL40fsWsn5PLU/uqKK5o4Wrz5jK8oUTWTRltNr9RYYhBUHANbR18eDmA3xz1Vam52dx18eWMC47g4vmjeerlya6OhEZCAqCAHJ3/vZyBfetL+fZV8O38ls8dTR3XHt6XG+HJyKDk4IgYMpqWvg/f32Fp3dVM3XMCD56VhEXzR/PosmjX/dGKyIyfCkIAqCxPXzbwmdereZ3z+whLTmJb18+j6uXTtOHv4goCIYrd+epXdX85NGdvFRej3v4VobL5o3n65fN0zh/ETlCQTAMvbK/ge/9fRvPlNQwZUwmnz//ZE6dNpqFU0YzagjeWUlE4ktBMIx09YT42epd3PJECTmZqXztnXO5+oypA3rPWhEZehQEw0RZTQs3rtzEpn31vPfUyXztsrnkZOrbv4i8MQXBMLB62yFuXLkJM/j5VYu5bOHxs36KiPRFQTCEuTu3PlXK9x/ezvyJOfzqw6f1Ov2DiMjrURAMUZ3dIf79gZe5f0M5ly6YwI/et/Co+wKIiMRKQTAENbV38anfv8iakmo+d/5MPn/+TF0PICJvmoJgiKlsaue6O9ax/WATN19xCu8rnpLokkRkiFMQDCGv7G/g0394kaqmDm67pphzZ41LdEkiMgwoCIaAzu4QP398F7948lXystK4Z8UZLJoyOtFlicgwoSAY5MpqWvjE3RvYfrCJ95w6ia+/cx45I3R9gIj0HwXBILa/vo0P/uYFWjq7ue0jxUduCyki0p8UBINUZWM7V//meRrbu7jn42cwf1JOoksSkWEqKdEFyPHqWjq5+rYXqGzq4HfXLVEIiEhcxTUIzGyZme0wsxIzu6mXx681syoz2xT5uT6e9QwVP129i93VLfz2mtM5bVpuossRkWEubk1DZpYM3AJcCJQD68xslbtvPWbTP7n7DfGqY6ipbelk5bq9XL5oEmeelJfockQkAOJ5RrAEKHH3UnfvBFYCl8fx/YaFu58ro70rxIqzpye6FBEJiHgGwSRgX9RyeWTdsd5rZpvN7H4z6/UyWTNbYWbrzWx9VVVVPGodFNo6e7jzuT2cN3scs8ZnJ7ocEQmIRHcW/w9Q6O6nAI8Cd/a2kbvf6u7F7l6cn58/oAUOpPs37KO2pZNP6GxARAZQPINgPxD9DX9yZN0R7l7j7h2RxduA0+JYz6DWE3J+8/RuFk0ZzZKiMYkuR0QCJJ5BsA6YaWZFZpYGXAmsit7AzCZELS4HtsWxnkHt/g372FvbyiffPh0zzSQqIgMnbqOG3L3bzG4AHgGSgdvdfYuZfQtY7+6rgM+Z2XKgG6gFro1XPYPZqpcO8O8PvELxtFwunDs+0eWISMCYuye6hhNSXFzs69evT3QZ/eb+DeV8+f6XKC4cw+3Xns7IdF3sLSL9z8w2uHtxb4/pUyeB/nvTfr5030u8dcZYfvORYt1hTEQSQkGQIPvr2/jqA6+wpHAMt11TTEaqQkBEEiPRw0cDyd35t7+8TMid/3j/QoWAiCSUgiAB7ltfzlM7q7jp4tlMGTMi0eWISMApCAZYRUMb3/7bVpYWjeFDS6cluhwREQXBQPvOg9vo7nF+eMUpJCXpegERSTwFwQDacqCBv71cwYqzpzMtLyvR5YiIAAqCAfWTR3eSk5nKx95WlOhSRESOUBAMkI1763hsWyUrzp7OqAzdfF5EBg8FwQD58aM7GZOVxrVvKUx0KSIiR1EQDIC1u2t5elc1n3r7SWRpCgkRGWQUBAPg54/vIj87nQ+doeGiIjL4KAjirKSymad3VXPNmdM0l5CIDEoKgjj7/fNlpCUnceWSqYkuRUSkVwqCOGrp6ObPG8q5ZMF4xo5MT3Q5IiK9UhDE0QMb99PU0c2HzyxMdCkiIn1SEMSJu3P3c2XMmziKU6eOTnQ5IiJ9UhDEydrdtew41MQ1ZxbqHsQiMqgpCOLkrufKyMlM5bKFExNdiojI61IQxMHemlb+/koFVy6ZoiGjIjLoKQji4LY1pSQnGR89S5PLicjgpyDoZzXNHdy7fh/vXjyJglEZiS5HROQNKQj62V3PldHeFWLF2dMTXYqISEwUBP2otbObO5/bwwVzCpgxLjvR5YiIxERB0I/uXbeP+tYuPnWOzgZEZOhQEPQTd+fO58o4bVoup00bk+hyRERipiDoJ69WNbO7uoV3LZ6U6FJERE6IgqCfPL69EoDzZo9LcCUiIidGQdBPVm+rZPb4bCaNzkx0KSIiJySuQWBmy8xsh5mVmNlNr7Pde83Mzaw4nvXES0NbF+vL6nQ2ICJDUtyCwMySgVuAi4G5wFVmNreX7bKBG4EX4lVLvD21s4qekHP+HAWBiAw98TwjWAKUuHupu3cCK4HLe9nu28APgPY41hJXT2yvJHdEKoum5Ca6FBGRExZTEJjZX8zsUjM7keCYBOyLWi6PrIt+3VOBKe7+tzd4/xVmtt7M1ldVVZ1ACfHXE3Ke2FHJObPGkZyk6aZFZOiJ9YP9F8AHgV1m9n0zm/XPvnEkVH4MfPGNtnX3W9292N2L8/Pz/9m37leb9tVT19rFueofEJEhKqYgcPfH3P1q4FRgD/CYmT1rZteZWWofT9sPTIlanhxZd1g2MB940sz2AGcAq4Zah/Hj2w+RnGS8febgCigRkVjF3NRjZnnAtcD1wEbgp4SD4dE+nrIOmGlmRWaWBlwJrDr8oLs3uPtYdy9090LgeWC5u69/MzuSKI9vr6J4Wi45I/rKQxGRwS3WPoIHgKeBEcBl7r7c3f/k7p8FRvb2HHfvBm4AHgG2Afe6+xYz+5aZLe+f8hNrf30b2yoaNWxURIa0lBi3+5m7P9HbA+7eZ1OOuz8EPHTMuq/1se05MdYyaBy+mvj8OQUJrkRE5M2LtWlorpmNPrxgZrlm9uk41TRkrN52iMK8EZyUn5XoUkRE3rRYg+Dj7l5/eMHd64CPx6ekoaG1s5tnX63hvNkFmGnYqIgMXbEGQbJFfdpFrhpOi09JQ8OaXdV0doe4QFcTi8gQF2sfwcPAn8zs15HlT0TWBdbqbZVkp6dwepHuPSAiQ1usQfAVwh/+n4osPwrcFpeKhoBQyFm9vZKzZ+WTmqwJXEVkaIspCNw9BPwy8hN4m/c3UN3coWYhERkWYgoCM5sJfI/wLKIZh9e7eyBvzvv4tkMkGZxzsoJARIa+WNs17iB8NtANnAvcBfw+XkUNdo9tq+S0abnkZgW6v1xEholYgyDT3VcD5u5l7v4N4NL4lTV4VTd3sLWiUZPMiciwEWtncUdkttBdZnYD4cnjep1aYrhbt7sWgKVFeQmuRESkf8R6RnAj4XmGPgecBnwIuCZeRQ1ma/fUkpGaxIJJOYkuRUSkX7zhGUHk4rEPuPuXgGbgurhXNYit3V3L4im5pKVo2KiIDA9v+Gnm7j3AWweglkGvsb2LbRWNLNFFZCIyjMTaR7DRzFYB9wEth1e6+1/iUtUgtaGsjpCjIBCRYSXWIMgAaoDzotY5EKggWLe7lpQkY/HU0W+8sYjIEBHrlcWB7hc4bO3uWuZPymFEWqz5KSIy+MV6ZfEdhM8AjuLuH+33igap9q4eNpc3cO1ZhYkuRUSkX8X61fbBqN8zgHcDB/q/nMHrpX31dPaEWFKo/gERGV5ibRr6c/Symd0DrIlLRYPU2siFZMWFuQmuRESkf73ZwfAzgUDNsbB2Ty2zx2czeoTmFxKR4SXWPoImju4jOEj4HgWB0N0T4sWyOt5z6uRElyIi0u9ibRrKjnchg9mOQ020dPaoWUhEhqWYmobM7N1mlhO1PNrM3hW/sgaXzeUNACycrOsHRGT4ibWP4Ovu3nB4wd3rga/Hp6TBZ3N5PTmZqUzLG5HoUkRE+l2sQdDbdoG5qmrTvgZOmZyDmSW6FBGRfhdrEKw3sx+b2UmRnx8DG+JZ2GDR1tnDzkNNahYSkWEr1iD4LNAJ/AlYCbQDn4lXUYPJ1ooGekLOKZN1/wERGZ5iHTXUAtwU51oGpU37wl0ji6bojEBEhqdYRw09amajo5ZzzeyR+JU1eGwur2f8qAzGjcpIdCkiInERa9PQ2MhIIQDcvY4Yriw2s2VmtsPMSszsuDMKM/ukmb1sZpvMbI2ZzY299IHx0r56NQuJyLAWaxCEzGzq4QUzK6SX2UijRW5xeQtwMTAXuKqXD/o/uvsCd18E/BD4cYz1DIiG1i721LSyUM1CIjKMxToE9KvAGjP7B2DA24AVb/CcJUCJu5cCmNlK4HJg6+EN3L0xavss3iBcBtrm/eGTII0YEpHhLNbO4ofNrJjwh/9G4K9A2xs8bRKwL2q5HFh67EZm9hngC0AaR98BLXqbFZH3ZurUqb1tEhcv7QsHwQI1DYnIMBZrZ/H1wGrgi8CXgLuBb/RHAe5+i7ufRHgSu//Txza3unuxuxfn5+f3x9vG5KXyBqaPzSInM3XA3lNEZKDF2kdwI3A6UObu5wKLgfrXfwr7gSlRy5Mj6/qyEhhU8xdtLldHsYgMf7EGQbu7twOYWbq7bwdmvcFz1gEzzazIzNKAK4FV0RuY2cyoxUuBXTHWE3eHGts51NjBKeofEJFhLtbO4vLIdQR/BR41szqg7PWe4O7dZnYD8AiQDNzu7lvM7FvAendfBdxgZhcAXUAdcM2b3ZH+tuVA+EIy9Q+IyHAXa2fxuyO/fsPMngBygIdjeN5DwEPHrPta1O83xl7qwNpW0QTA7PGBvhWDiATACc8g6u7/iEchg83WA41MGZNJdoY6ikVkeHuz9ywe9rZVNDJn/KhElyEiEncKgl60dnazu6aFuRMVBCIy/CkIerHjYBPuMGeCgkBEhj8FQS8OdxTPVRCISAAoCHqxtaKB7PQUJudmJroUEZG4UxD0YltFE7MnZOsexSISCAqCY4RCzvaKRjULiUhgKAiOsa+ulZbOHnUUi0hgKAiOsa0ifIsEBYGIBIWC4BhbK5pIMpilqSVEJCAUBMfYeqCRorFZZKQmJ7oUEZEBoSA4xraKRuZO1IyjIhIcCoIoDW1d7K9vY84ENQuJSHAoCKLsOBi+olgdxSISJAqCKDsOhYNgVoHOCEQkOBQEUXYdaiI7PYUJORmJLkVEZMAoCKLsONjEzIKRmlpCRAJFQRBlV2UzJ6tZSEQCRkEQUd3cQW1LJzMVBCISMAqCiJ2RjuKTC0YmuBIRkYGlIIjYeVAjhkQkmBQEETsrm8nJTCU/Oz3RpYiIDCgFQcSuQ02crBFDIhJACgLA3dl5SCOGRCSYFARAZVMHDW1dCgIRCSQFAa+NGJqpEUMiEkAKAmDnoWYAnRGISCDFNQjMbJmZ7TCzEjO7qZfHv2BmW81ss5mtNrNp8aynLzsPNpGXlcbYkRoxJCLBE7cgMLNk4BbgYmAucJWZzT1ms41AsbufAtwP/DBe9byenZVNahYSkcCK5xnBEqDE3UvdvRNYCVwevYG7P+HurZHF54HJcaynV+5OiUYMiUiAxTMIJgH7opbLI+v68jHg73Gsp1cVDe00dXRrjiERCayURBcAYGYfAoqBt/fx+ApgBcDUqVP79b2PzDE0Tk1DIhJM8Twj2A9MiVqeHFl3FDO7APgqsNzdO3p7IXe/1d2L3b04Pz+/X4ssrWoBYIaCQEQCKp5BsA6YaWZFZpYGXAmsit7AzBYDvyYcApVxrKVPpdXNjMpIYUxWWiLeXkQk4eIWBO7eDdwAPAJsA+519y1m9i0zWx7Z7GZgJHCfmW0ys1V9vFzc7K5uYXq+5hgSkeCKax+Buz8EPHTMuq9F/X5BPN8/FqVVLZw5PS/RZYiIJEygryxu7eymoqGdorFZiS5FRCRhAh0Ee6rDlzBMz1dHsYgEV6CDoLQ6PMeQzghEJMgCHQS7I0NHFQQiEmSBDoLS6hYm5mSQmZac6FJERBIm8EFQlK+zAREJtsAGgbuzu6qZ6WPVUSwiwRbYIKhp6aSxvVv9AyISeIENgt3V4Y7i6WoaEpGAC2wQlFaFh46qaUhEgi64QVDdQlpyEpNyMxNdiohIQgU2CHZXtTAtbwTJSZpsTkSCLbBBUFrdoo5iERECGgQ9IaesRtcQiIhAQIOgvK6Vrh7nJHUUi4gEMwhKI0NHdUYgIhLQINBkcyIirwlkEJTVtJCdnkKe7lMsIhLMINhT08q0sSN0n2IREQIaBGU1LUzLU7OQiAgEMAi6ekLsq2ujMG9EoksRERkUAhcE++va6Ak5hTojEBEBAhgEe2rCI4YKNWJIRAQIYBCU1bQCME1NQyIiQACDYHd1C1lpyeSPTE90KSIig0LgguDwiCENHRURCQtgELRSOFbNQiIihwUqCLp7QuytbdWIIRGRKCsiPM4AAAdYSURBVIEKggP17XRr6KiIyFHiGgRmtszMdphZiZnd1MvjZ5vZi2bWbWZXxLMWeG3oqEYMiYi8Jm5BYGbJwC3AxcBc4Cozm3vMZnuBa4E/xquOaGW6hkBE5DgpcXztJUCJu5cCmNlK4HJg6+EN3H1P5LFQHOs4Ynd1K5mpyYzL1tBREZHD4tk0NAnYF7VcHll3wsxshZmtN7P1VVVVb7qg8NBRzToqIhJtSHQWu/ut7l7s7sX5+flv+nX21LSoo1hE5BjxDIL9wJSo5cmRdQnRE3L21bapf0BE5BjxDIJ1wEwzKzKzNOBKYFUc3+91Hahvo7MnpOmnRUSOEbcgcPdu4AbgEWAbcK+7bzGzb5nZcgAzO93MyoH3Ab82sy3xque1yeZ0RiAiEi2eo4Zw94eAh45Z97Wo39cRbjKKu9emn9YZgYhItCHRWdwfxmWnc+HcAgqyMxJdiojIoBLXM4LB5B3zxvOOeeMTXYaIyKATmDMCERHpnYJARCTgFAQiIgGnIBARCTgFgYhIwCkIREQCTkEgIhJwCgIRkYAzd090DSfEzKqAsjf59LFAdT+WM1QEcb+DuM8QzP0O4j7Die/3NHfvdR7/IRcE/wwzW+/uxYmuY6AFcb+DuM8QzP0O4j5D/+63moZERAJOQSAiEnBBC4JbE11AggRxv4O4zxDM/Q7iPkM/7neg+ghEROR4QTsjEBGRYygIREQCLjBBYGbLzGyHmZWY2U2JricezGyKmT1hZlvNbIuZ3RhZP8bMHjWzXZH/5ia61v5mZslmttHMHowsF5nZC5Hj/SczS0t0jf3NzEab2f1mtt3MtpnZmQE51v8S+ff9ipndY2YZw+14m9ntZlZpZq9Erev12FrYzyL7vtnMTj3R9wtEEJhZMnALcDEwF7jKzOYmtqq46Aa+6O5zgTOAz0T28yZgtbvPBFZHloebG4FtUcs/AH7i7jOAOuBjCakqvn4KPOzus4GFhPd/WB9rM5sEfA4odvf5QDJwJcPveP8OWHbMur6O7cXAzMjPCuCXJ/pmgQgCYAlQ4u6l7t4JrAQuT3BN/c7dK9z9xcjvTYQ/GCYR3tc7I5vdCbwrMRXGh5lNBi4FbossG3AecH9kk+G4zznA2cBvAdy9093rGebHOiIFyDSzFGAEUMEwO97u/hRQe8zqvo7t5cBdHvY8MNrMJpzI+wUlCCYB+6KWyyPrhi0zKwQWAy8ABe5eEXnoIFCQoLLi5T+BLwOhyHIeUO/u3ZHl4Xi8i4Aq4I5Ik9htZpbFMD/W7r4f+BGwl3AANAAbGP7HG/o+tv/051tQgiBQzGwk8Gfg8+7eGP2Yh8cLD5sxw2b2TqDS3TckupYBlgKcCvzS3RcDLRzTDDTcjjVApF38csJBOBHI4vgmlGGvv49tUIJgPzAlanlyZN2wY2aphEPgD+7+l8jqQ4dPFSP/rUxUfXFwFrDczPYQbvI7j3Db+ehI0wEMz+NdDpS7+wuR5fsJB8NwPtYAFwC73b3K3buAvxD+NzDcjzf0fWz/6c+3oATBOmBmZGRBGuHOpVUJrqnfRdrGfwtsc/cfRz20Crgm8vs1wH8PdG3x4u7/5u6T3b2Q8HF93N2vBp4ArohsNqz2GcDdDwL7zGxWZNX5wFaG8bGO2AucYWYjIv/eD+/3sD7eEX0d21XARyKjh84AGqKakGLj7oH4AS4BdgKvAl9NdD1x2se3Ej5d3AxsivxcQrjNfDWwC3gMGJPoWuO0/+cAD0Z+nw6sBUqA+4D0RNcXh/1dBKyPHO+/ArlBONbAN4HtwCvA3UD6cDvewD2E+0C6CJ/9fayvYwsY4VGRrwIvEx5RdULvpykmREQCLihNQyIi0gcFgYhIwCkIREQCTkEgIhJwCgIRkYBTEIhEmFmPmW2K+um3CdvMrDB6JkmRwSTljTcRCYw2d1+U6CJEBprOCETegJntMbMfmtnLZrbWzGZE1hea2eOROeBXm9nUyPoCM3vAzF6K/Lwl8lLJZvabyFz6/2tmmZHtPxe5h8RmM1uZoN2UAFMQiLwm85imoQ9EPdbg7guA/yI82ynAz4E73f0U4A/AzyLrfwb8w90XEp7/Z0tk/UzgFnefB9QD742svwlYHHmdT8Zr50T6oiuLRSLMrNndR/ayfg9wnruXRib1O+jueWZWDUxw967I+gp3H2tmVcBkd++Ieo1C4FEP31QEM/sKkOru3zGzh4FmwtNE/NXdm+O8qyJH0RmBSGy8j99PREfU7z281kd3KeG5Yk4F1kXNoikyIBQEIrH5QNR/n4v8/izhGU8Brgaejvy+GvgUHLmXck5fL2pmScAUd38C+AqQAxx3ViIST/rmIfKaTDPbFLX8sLsfHkKaa2abCX+rvyqy7rOE7xD2r4TvFnZdZP2NwK1m9jHC3/w/RXgmyd4kA7+PhIUBP/PwLSdFBoz6CETeQKSPoNjdqxNdi0g8qGlIRCTgdEYgIhJwOiMQEQk4BYGISMApCEREAk5BICIScAoCEZGA+//t51sUeflK2AAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAEGCAYAAABvtY4XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3de3hcd33n8fd3NLqNNBrrLtmyLTu+O7GT2HGcC2kukIaQQrmVW2kJPJstS1vYUtrQy+7TpV3odjel2bKUEAgp0FJKgIYQQu4kLUlsOTffHduxbMvWxZJ1v4703T9mLMuJ7Ci2jkc683k9jx5rjkZzvkdH/ujM9/zO75i7IyIi4RPJdAEiIhIMBbyISEgp4EVEQkoBLyISUgp4EZGQima6gIkqKiq8vr4+02WIiMwaW7ZsOebulZN9bUYFfH19PQ0NDZkuQ0Rk1jCzxtN9TS0aEZGQUsCLiISUAl5EJKQU8CIiIaWAFxEJqUAD3szmmNkPzGyXme00syuCXJ+IiJwU9DDJvwMecvf3mVkeEAt4fSIikhbYEbyZJYBrgG8AuPuwu3dO93rcnTsfe4Wn9rRN90uLiMxqQbZoFgFtwD1m9oKZ3W1mRdO9EjPjrqf28+RuBbyIyERBBnwUuBT4qrtfAvQBt7/2SWZ2m5k1mFlDW9vZhXSiMJfOgeFzKlZEJGyCDPjDwGF3fy79+AekAv8U7n6Xu6939/WVlZNOp/CGEoW5dA+MnH2lIiIhFFjAu3szcMjMlqcX3QDsCGJdc2K5dPYr4EVEJgp6FM3vAd9Nj6DZD9waxEoShbnsbe0N4qVFRGatQAPe3V8E1ge5DkgfwatFIyJyilBcyVpSmEtX/wjunulSRERmjFAE/JzCPIZHxxgcGct0KSIiM0Y4Aj6WC6ChkiIiE4Qi4BOFqYDvUh9eRGRcKAJ+TjrgNVRSROSkUAR8iY7gRUReJxQBf6IH36UjeBGRcaEIePXgRUReLxQBX5wfJSdiGkUjIjJBKALezEgU5uoIXkRkglAEPKRG0mgUjYjISaEJ+ERMR/AiIhOFJ+DVohEROUVoAl4tGhGRU4Um4HUELyJyqvAEfCyP7sERxsY0ZbCICIQp4AtzcYeewWSmSxERmRFCE/DjE47pYicRESBMAR/TdAUiIhOFJuATmjJYROQUoQl4HcGLiJwqNAFfMt6DV8CLiECIAn58yuB+nWQVEYEQBXx+NIfC3By1aERE0kIT8JDqw+skq4hISqgCXtMViIicFLqA10lWEZGUUAX8nFgu3Qp4EREgZAGf0JTBIiLjQhXwc2J56sGLiKSFKuAThbkMjIwyODKa6VJERDIudAEPqA8vIkJIA15tGhGRkAX8iQnHNFRSRCRsAV+YB0CXRtKIiIQr4BOaUVJEZFw0yBc3swNADzAKJN19fZDrS2hOeBGRcYEGfNp17n7sPKyHeH4UM00ZLCICIWvRRCKmCcdERNKCDngHHjazLWZ222RPMLPbzKzBzBra2trOeYVlsTyO9ekIXkQk6IC/2t0vBd4OfMrMrnntE9z9Lndf7+7rKysrz3mFFfF82nqGzvl1RERmu0AD3t2b0v+2Aj8CNgS5PoAqBbyICBBgwJtZkZnFT3wO3AhsC2p9J1TFC2jtHgx6NSIiM16Qo2iqgR+Z2Yn1/JO7PxTg+gCojOfTNzxK31CSovzzMUhIRGRmCiwB3X0/sDao1z+dqng+AG09Qwp4EclqoRomCVBVkgr4VvXhRSTLhS/g4wUAtPaoDy8i2S10AV85oUUjIpLNQhfwpbFccnNMLRoRyXqhC3gzo7I4n9ZuBbyIZLfQBTyk2jTqwYtItgtpwBeoBy8iWS+UAV9VoukKRETCGfDxfNr7hhkZHct0KSIiGRPKgD8xVPJYr47iRSR7hTLgT1zspDaNiGSzkAZ8eroCDZUUkSwWyoA/0aLRxU4iks1CGfAVxScCXmPhRSR7hTLg86IRyory1IMXkawWyoCHVB9eLRoRyWahDfhKBbyIZLlQB3yb7s0qIlkstAFfFS+grXcId890KSIiGRHagK+M5zMy6nT2j2S6FBGRjAhtwFdpLLyIZLksCHj14UUkO4U34Es0H42IZLfQBrymKxCRbBfagC/OjxLLy9GEYyKStUIb8HDialb14EUkO4U64GsThTR1DmS6DBGRjAh1wC8sj3GwvT/TZYiIZESoA35BeYz2vmF6h5KZLkVE5LwLdcAvLCsCoLG9L8OViIicf+EO+PIYgNo0IpKVQh3wC9IB39ihgBeR7BPqgC8pyKU0lkujjuBFJAuFOuABFpQXcbBDPXgRyT6hD/iFZTEdwYtIVgo84M0sx8xeMLMHgl7XZBaWxzjSOcBwciwTqxcRyZjzcQT/aWDneVjPpBaUxRhzdEWriGSdQAPezOqAdwB3B7meM1lYrrHwIpKdgj6C/zLwR8Bp+yNmdpuZNZhZQ1tb27QXMD4WXkMlRSTLBBbwZnYL0OruW870PHe/y93Xu/v6ysrKaa+jKp5PQW5EFzuJSNYJ8gj+KuCdZnYA+B5wvZl9J8D1TcrMWFAW08VOIpJ1Agt4d/+8u9e5ez3wQeBxd//NoNZ3JgvKinQELyJZZ0oBb2afNrMSS/mGmT1vZjcGXdx0WVge42BHP+6e6VJERM6bqR7Bf9zdu4EbgVLgo8CXproSd3/S3W85i/qmxcLyGAMjo7oBt4hklakGvKX/vRn4trtvn7BsxltQpknHRCT7TDXgt5jZw6QC/udmFucMQx9nmpNj4RXwIpI9olN83ieAi4H97t5vZmXArcGVNb3mzSkkYnBQFzuJSBaZ6hH8FcBud+80s98E/gzoCq6s6ZUXjTB3TqFaNCKSVaYa8F8F+s1sLfBZYB/wj4FVFYD68iJePaYjeBHJHlMN+KSnxhi+C/h7d/8KEA+urOm3vCbOnpYeRsc0VFJEssNUA77HzD5PanjkT80sAuQGV9b0W1ETZ3BkTJOOiUjWmGrAfwAYIjUevhmoA/4msKoCsLK2BIBdzT0ZrkRE5PyYUsCnQ/27QCI9idigu8+qHvySqmJyIsbOo92ZLkVE5LyY6lQFvwFsAt4P/AbwnJm9L8jCpltBbg6LK4rYeVRH8CKSHaY6Dv5PgcvcvRXAzCqBR4EfBFVYEFbUlvB84/FMlyEicl5MtQcfORHuae1v4ntnjJW1cZo6B+geHMl0KSIigZtqSD9kZj83s4+Z2ceAnwIPBldWMFbWpE607taJVhHJAlM9yfo54C5gTfrjLnf/4yALC8KK2tTQfZ1oFZFsMNUePO5+H3BfgLUErqakgERhrk60ikhWOGPAm1kPMNmlnwa4u5cEUlVAzIyVtXF2NesIXkTC74wB7+6zajqCqVhRU8L3Gw4xNuZEIrNmSnsRkTdt1o2EOVcra+P0D49yUDNLikjIZWHAn5iyQG0aEQm3rAv4pVVxIgY7dKJVREIu6wK+MC+H+ooidmmopIiEXNYFPMCq2hK2Nc2aG1KJiJyVrAz4dQtLOdI1SFPnQKZLEREJTFYG/GX1ZQBsfrUjw5WIiAQnKwN+ZW0J8fwomw4o4EUkvLIy4HMixqULS2lQwItIiGVlwANsWFTGnpZejvcNZ7oUEZFAZG3An+jDN+gGICISUlkb8GvqEuTlRNisNo2IhFTWBnxBbg5r6hJs0kgaEQmprA14gMsWlbGtqYv+4WSmSxERmXZZHfAb6stIjjkvHuzMdCkiItMuqwP+0oWlmMHmAzrRKiLhk9UBnyjMZUVNiU60ikgoZXXAA1y+qIyGxg4GR0YzXYqIyLTK+oC/dnklgyNjPLO/PdOliIhMq8AC3swKzGyTmb1kZtvN7C+CWte52Li4nFheDo/vbM10KSIi0yrII/gh4Hp3XwtcDNxkZhsDXN9ZKcjN4eolFTy+qxV3z3Q5IiLTJrCA95Te9MPc9MeMTNAbVlbR1DnA7hbdxk9EwiPQHryZ5ZjZi0Ar8Ii7PzfJc24zswYza2hrawuynNO6bnkVAI+pTSMiIRJowLv7qLtfDNQBG8zswkmec5e7r3f39ZWVlUGWc1pVJQWsqUvw2M6WjKxfRCQI52UUjbt3Ak8AN52P9Z2N61dU8cKhTtp7hzJdiojItAhyFE2lmc1Jf14IvA3YFdT6ztUNK6pxhyd3Z6ZNJCIy3YI8gq8FnjCzl4HNpHrwDwS4vnOyem4JVfF8Ht+lPryIhEM0qBd295eBS4J6/ekWiRg3rKziJy8dZXBklILcnEyXJCJyTrL+StaJfm3tXHqHkjy49WimSxEROWcK+AmuWFxOfXmM7206lOlSRETOmQJ+AjPjA5ctYNOBDva29r7xN4iIzGAK+Nd437o6ohHjXzYfzHQpIiLnRAH/GpXxfN66spr7nm9iKKkphEVk9lLAT+KDG+bT0TfMIzt0ZauIzF4K+Em8ZWkl8+YU6mSriMxqCvhJ5ESMD1w2n3/fe4x9bTrZKiKzkwL+ND58+QLyoxHufnp/pksRETkrCvjTqCjO573r6rjv+SbaejQBmYjMPgr4M/hPb1nMyOgY9/7yQKZLERF50xTwZ7CooogbV1Xz7Wcb6RtKZrocEZE3RQH/Bm675gK6Bkb4foNG1IjI7KKAfwPrFpayfmEpdz/9KiOjY5kuR0RkyhTwU/Cp65bQ1DnA3U+/mulSRESmTAE/BdetqOKm1TX87aN72K9x8SIySyjgp+h/vGs1BdEIt9+3lbExz3Q5IiJvSAE/RVUlBfzZLavYdKCDf9qkmSZFZOZTwL8J719Xx9VLKvjSz3ZxtGsg0+WIiJyRAv5NMDO++J6LSI6N8ec/3o67WjUiMnMp4N+k+WUx/uBty3h0ZwsPbWvOdDkiIqelgD8LH79qEavnlvDf7t9O18BIpssREZmUAv4sRHMifOk9a2jvHeJLP9uV6XJERCalgD9LF9Ul+PhVi/jnTQd5YldrpssREXkdBfw5+IMbl7GqtoRP/dPzbGvqynQ5IiKnUMCfg1helHtuvYzSWB63fmszh4/3Z7okEZFxCvhzVF1SwD23XsbgyCi33rOZrn6ddBWRmUEBPw2WVcf52kfX0djez0e+8SzH+4YzXZKIiAJ+ulx5QQVf++g69rT08uG7n6O9V7f5E5HMUsBPo+tWVHH3b61nf1svH/76c7R2D2a6JBHJYgr4aXbNskru+dhlHOzo5+Y7n+YXe9oyXZKIZCkFfACuXFLBv/3uVZQV5fHb39zEFx/cyXBSd4MSkfNLAR+QZdVx7v/dq/nI5Qv42lP7+fi3NuvG3SJyXingA1SQm8Nfvfsi/uZ9a3hmfzsfvvs5jbARkfNGAX8evH/9fP7hN9ex82g37//aMzR1ai55EQleYAFvZvPN7Akz22Fm283s00GtazZ426pqvv3xDbR0DfL2Lz/Fj19o0nzyIhKoII/gk8Bn3X0VsBH4lJmtCnB9M97li8v5ye9dzdLqOJ/5lxf55Heep61H4+VFJBiBBby7H3X359Of9wA7gXlBrW+2qK8o4vv/+Qpuf/sKHt/VyrV/8wR3PLKH7kFNcSAi08vOR5vAzOqBp4AL3b37NV+7DbgNYMGCBesaGxsDr2em2Nvayx2P7ObBrc3MieXy0Y0LuenCGlbVlmBmmS5PRGYBM9vi7usn/VrQAW9mxcAvgL9y9x+e6bnr16/3hoaGQOuZibY1dfF/Ht7Nk3vacIf5ZYV8YP18brvmAvKiOg8uIqeXsYA3s1zgAeDn7n7HGz0/WwP+hGO9Qzy6o4Wfbj3K068cY/XcEu74jYtZXhPPdGkiMkNlJOAt1WO4F+hw989M5XuyPeAn+vn2Zv7kh1vpGUzyX667gN+6op6yorxMlyUiM0ymAv5q4GlgK3DiOv0/cfcHT/c9CvhTHesd4s9/vI2fbWsmLxrhljW1vG9dHatrEyRiuZkuT0RmgIz24N8MBfzk9rT08O1nGvnh84fpGx4FoLokn1W1JWxcXM6VF1Swam4JORGdmBXJNgr4kOgdSrL51Q72tPSwu6WHrYe7eKW1F4DSWC43rqrhHWtqueKCcnJzdHJWJBso4EOstXuQZ/a388SuVh7d2UrvUJI5sVyuW17F9SuquGZZJYlCtXNEwkoBnyUGR0Z5ak8bP9vWzJO7WzneP0I0Yrx1ZTUf3DCftyytJGJwpGuQg+39LK+J68StyCx3poCPnu9iJDgFuTncuLqGG1fXMDrmvHjoOD/b2swPX2jioe3NVBTnMzCcHO/jRwzWLyzjbauqeduqauorijK8BSIynXQEnwWGkqM8sqOFh7e3UFaUx5KqYuaVFvJC43Ee3tHCruYeAJZUFfPWldXMLysc/96B4VG6B5P0DI6wcXE5v7q6JlObISKTUItGzuhQRz+P7mzh0Z0tPLe/g+TY638n8qMRhpJjfPLaC/jcjcuJaMSOyIygFo2c0fyyGLdetYhbr1pE31By/M5TTqrtU5wfZXTM+e/3b+erT+5jb2svf/3eNeREjOToGG29Q+xu7mFXcw/DyTGuvKCcjYvLKcrXr5dIJukIXqbM3fnWLw/whQd2MMlBPtGIEYkYw8kxcnOMlbUlJApziRdESRTmUlcaY35ZjNpEAREDdxgZdVp7BmnuGqSjf5gLKopZMz/B0qr4Gcf1uzv9w6PE8nI0MZtkNR3By7QwM269ahFr6hJsPnCc3JwIuTlGojCX5TVxFlcUM+bOlsbjPP3KMbYf6aJ3KElz1yDH+4c51nvm2xVGIzbeHorl5bBuYSlXLalgw6IymrsGaThwnBcOHedo5yAdfcMMj45xQWURv/MrF/Drl8w749j/PS09fOGBHRzs6Of96+r40IYFlBfnT3nbB4ZH2XG0mzV1ibO6xmBwZJT8aER/jOS80hG8nDf9w0kOHx+guWsQB4xUqFeV5FNdUkBRXpRX2/t4+XAnLxzs5Jl97eMXckHqPMDa+XOoL49RWpRHPD/KT7c2s/NoN3MTBVy9tIK8aIS8nBwShbnMKy1kbqKAR3e2cu8zByjOj7KyNs6z+zvIy4lwy9paPnZlPWvq5gCpdwXbmrppaOygNJZHVTwfB+5/8Qg/3XqU3qEkK2ri/NW7L2TdwrJJt9Hd2d3Sw8PbW3h8VytNnQN0DYwwnBxjWXUxn3nrMm5aXUMkYoyNOTuOdrO1qYu9rb3sbe0lJ2Jcu7yS61dUUVcaYyg5Smv3EMOjYywsixHN4AVs/cNJ3Alt6y05Opaxn6+7n/Uff51klVmrpXuQLY3HqU0UsHpu4nXTJ7s7T+5p4+tP7Wd/Wx/Do2MMJ8foTZ9HADCDD21YwB/euJyyojz2tvbyj88c4L4tqakfLlkwhw2Lynhkewv7j/W9roZYXg7vuKiWtfPn8P+e2MuRrkHec+k8akoKaO4epK1niO6BEXqHknQNjIy/U7l4/hxW1MRJFOZSmJfDT146wr62PlbUxFlcWcQz+9o53p+60Ut+NMLiymIGhpMcaO8HoKQgSvfgye3Ii0ZYVl3MypoSLpyX4MJ5CZbXxClKt6nGxpymzgH2tPRw+PgAly4o5cJ5J+8tcLxvmGf3t1NcEGVpVZzqkvwphUpjex/3/McB/rXhEGbGH964jI9eUX/GFlr/cJIvP/oKD249yud+dTnvXDs30HcvQ8lRvv7Ufva29nLhvAQXzUuwrDrOnFjuG6738PF+/ueDO/nZtmZW1ZZwzbJK3rK0gpU1JZSmrxMZHBnl+YPH2dbUxVuWVrKytuS0rzc4Msrx/mEGR8YYSo6SKMylpqRg0jp6h5J87Rf72NbUxTc/dtlZ/YwU8JJ1BkdGae4apKlzgOqSApZUFb/uOd2DI9y35TD3/vIAjR39XL6ojF+/eB7XLq+idyhJW88QAyNJLl908oRx31CSv3vsFb75768CUBXPp7KkgERhLsX5qRPSF88v5a0rq6gqKThlfaNjzk9eOsJXnthL31CSKy6o4Oql5axbUEZdaeH4yKT9bb08trOVgx39VMVT724iEWNPSw87j3az40g37X2ntrvyciJgMJwcO2X5vDmFXLOskj0tPbxw8Pgp507i+VEWVxWzpLJ4fOhsRXEelcX5HO0apOFAB8+92sGmAx1EI8avrZnLsb5hntrTxtq6BB+/ehGt3UMc7OhncGSUNXUJLllQmpok79+2cahjgIXlMRrb+7lpdQ1/+e4LKYvl0TkwQt9QkrrSwlMCbWB4lJ+8dAQzqE0UUhHPY3dzD8/sa2fTqx3E8nNYXZtg9bwSLpqXYNXcEvKjOWxr6uKz33+J3S09VBTnc6z35G0w86IRquL5LCyPcVl9GRsXl7O8Ok734AjtfcP8Yncb//CLfZjBey6tY29rL883Hh9vFZYV5VFTUsDe1l6GR0/+bG9aXcPv37CUVXNPBv3Oo91859lGfvRCE/3pa03Gf9YFUZZWFbOyNlX7hfMSvHy4izse2cOx3iHeuXYuf/3eNRTm5ZzmN/r0FPAiZzA25vQNJ4kXTH1Kh8GRUfJyIhkZLuruNHcPsq2pm72tvQyOjDKUHMPdqa8oYll1nJpEAb/ce4yHtjXzH/uOsbQqPj51xVBylH2tvbySbgvtbe2ldZJ7A0cMVs0t4frlVXxk40KqSwpwd+5/6QhfeGDH+DuVkoIouTmRU/7oLK4s4ovvvoj19WV8/en93PHwHsxSf+ROhOfK2hJuvaqemy+q5UfPH+bOx/dOeo/ieEGUyxeVMZQcY1tT1/i7nrycCMtr4uw42k15UR5ffM9F3LCymraeIbY2dbK/rY+2niFae1KjvHY2dzNZ3N2yppbP37ySeXNS13/0DI7Q0Hicfa297GvrpalzkBU1cTYuLmNZdZzvNxzmnn9/lZ6hJPH8KEX5UfKiEQ529JMfjfBra+eyfmEpBbk55EUjHOsdYk9LD3taetl5tJueCe/KLqsv5U9uXsklC0rP+vdBAS8iZ9Q1MEJL9yDHeoZo6x2irCiPSxaUUnyafnvP4AiN7f3ML42RiOXi7hw+PsCLhzrpG0ry7kvnkR89eTS6p6WH7z7bSFF+dPzcxvc2HWJ3Sw8RgzGHDfVlfPbGZdQkCmjuGqSlZ4j68hir5ybG20HuzpGuQV4+1MmLhzp56XAniyqKuf2mFW84hXZX/wibD3RwoL2PObE8yovymF8Wm/Td3Rv+vPpH+NcthzjSOUjv0Ah9Q6OsnZ/g/evmj7d1JjM25jR29LO1qYuSgii/sqzynFtXCngRmXHcnWf2tfPQ9mauW1HFtdMQdtlIwyRFZMYxM65cUsGVSyoyXUpoadJwEZGQUsCLiISUAl5EJKQU8CIiIaWAFxEJKQW8iEhIKeBFREJKAS8iElIz6kpWM2sDGs/y2yuAY9NYzmyQjdsM2bnd2bjNkJ3b/Wa3eaG7V072hRkV8OfCzBpOd7luWGXjNkN2bnc2bjNk53ZP5zarRSMiElIKeBGRkApTwN+V6QIyIBu3GbJzu7NxmyE7t3vatjk0PXgRETlVmI7gRURkAgW8iEhIzfqAN7ObzGy3me01s9szXU9QzGy+mT1hZjvMbLuZfTq9vMzMHjGzV9L/nv3NHWcoM8sxsxfM7IH040Vm9lx6n/+LmZ3+HmmzlJnNMbMfmNkuM9tpZleEfV+b2X9N/25vM7N/NrOCMO5rM/ummbWa2bYJyybdt5ZyZ3r7XzazS9/MumZ1wJtZDvAV4O3AKuBDZrYqs1UFJgl81t1XARuBT6W39XbgMXdfCjyWfhw2nwZ2Tnj818DfuvsS4DjwiYxUFay/Ax5y9xXAWlLbH9p9bWbzgN8H1rv7hUAO8EHCua+/Bdz0mmWn27dvB5amP24DvvpmVjSrAx7YAOx19/3uPgx8D3hXhmsKhLsfdffn05/3kPoPP4/U9t6bftq9wK9npsJgmFkd8A7g7vRjA64HfpB+Shi3OQFcA3wDwN2H3b2TkO9rUrcQLTSzKBADjhLCfe3uTwEdr1l8un37LuAfPeVZYI6Z1U51XbM94OcBhyY8PpxeFmpmVg9cAjwHVLv70fSXmoHqDJUVlC8DfwSMpR+XA53unkw/DuM+XwS0AfekW1N3m1kRId7X7t4E/G/gIKlg7wK2EP59fcLp9u05ZdxsD/isY2bFwH3AZ9y9e+LXPDXmNTTjXs3sFqDV3bdkupbzLApcCnzV3S8B+nhNOyaE+7qU1NHqImAuUMTr2xhZYTr37WwP+CZg/oTHdelloWRmuaTC/bvu/sP04pYTb9nS/7Zmqr4AXAW808wOkGq/XU+qNz0n/TYewrnPDwOH3f259OMfkAr8MO/rtwKvunubu48APyS1/8O+r0843b49p4yb7QG/GViaPtOeR+qkzP0ZrikQ6d7zN4Cd7n7HhC/dD/x2+vPfBv7tfNcWFHf/vLvXuXs9qX37uLt/BHgCeF/6aaHaZgB3bwYOmdny9KIbgB2EeF+Tas1sNLNY+nf9xDaHel9PcLp9ez/wW+nRNBuBrgmtnDfm7rP6A7gZ2APsA/400/UEuJ1Xk3rb9jLwYvrjZlI96ceAV4BHgbJM1xrQ9l8LPJD+fDGwCdgL/CuQn+n6Atjei4GG9P7+MVAa9n0N/AWwC9gGfBvID+O+Bv6Z1HmGEVLv1j5xun0LGKmRgvuAraRGGU15XZqqQEQkpGZ7i0ZERE5DAS8iElIKeBGRkFLAi4iElAJeRCSkFPASemY2amYvTviYtkm6zKx+4qyAIjNJ9I2fIjLrDbj7xZkuQuR80xG8ZC0zO2Bm/8vMtprZJjNbkl5eb2aPp+fffszMFqSXV5vZj8zspfTHlemXyjGzr6fnMn/YzArTz//99Pz9L5vZ9zK0mZLFFPCSDQpf06L5wISvdbn7RcDfk5q5EuD/Ave6+xrgu8Cd6eV3Ar9w97Wk5obZnl6+FPiKu68GOoH3ppffDlySfp3fCWrjRE5HV7JK6JlZr7sXT7L8AHC9u+9PT+TW7O7lZnYMqHX3kfTyo+5eYWZtQJ27D014jXrgEU/dqAEz+2Mg193/0sweAnpJTTXwY3fvDXhTRU6hI3jJdn6az9+MoQmfj3Ly3NY7SM0jcimwecKsiCLnhQJest0HJvz7TPrzX5KavRLgI8DT6c8fAz4J4/eJTZzuRc0sAu8xcAgAAACSSURBVMx39yeAPwYSwOveRYgESUcUkg0KzezFCY8fcvcTQyVLzexlUkfhH0ov+z1Sd1P6HKk7K92aXv5p4C4z+wSpI/VPkpoVcDI5wHfSfwQMuNNTt90TOW/Ug5esle7Br3f3Y5muRSQIatGIiISUjuBFREJKR/AiIiGlgBcRCSkFvIhISCngRURCSgEvIhJS/x9irFJdhc13LwAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "oh8ZdMXVgvCm",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "oh8ZdMXVgvCm"
       },
+      "outputs": [],
       "source": [
         "seed_text = \"sweet jeremy saw dublin\"\n",
         "\n",
         "token_list = tokenizer.texts_to_sequences([seed_text])[0]\n",
         "token_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')\n",
         "#print(model.predict(token_list))  \n",
-        "predicted = model.predict_classes(token_list)\n",
-        "pred_classes=model.predict(token_list)\n",
+        "pred_classes = model.predict(token_list, verbose=0)\n",
+        "predicted = np.argmax(pred_classes,axis=-1)\n",
         "print(pred_classes.reshape(-1)[predicted])\n",
         "print(predicted)\n",
         "for word, index in tokenizer.word_index.items():\n",
         "\tif index == predicted:\n",
         "\t\tprint(word)\n",
         "\t\tbreak"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 35,
       "metadata": {
-        "id": "6Vc6PHgxa6Hm",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 54
         },
+        "colab_type": "code",
+        "id": "6Vc6PHgxa6Hm",
         "outputId": "4853ff58-839e-4f2b-f66a-f5c7cbe43579"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "are you feeling lucky the hail the morning air where the place where we sat side by them spend oh my kellswater so fair for this one shadow on my wild throbbing breast hid her thousand treasures with such yet was seen for the song of the star of the very next day and mother i eyes are smiling sure tis like the morn in spring the landlord and the storied evening after live oh shed a tear in the high rocky slopes round the red came and slower and they would support her could not bring rosin the wheel leave where i was\n"
+          ]
+        }
+      ],
       "source": [
         "seed_text = \"are you feeling lucky\"\n",
         "next_words = 100\n",
@@ -298,7 +294,9 @@
         "for _ in range(next_words):\n",
         "\ttoken_list = tokenizer.texts_to_sequences([seed_text])[0]\n",
         "\ttoken_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')\n",
-        "\tpredicted = model.predict_classes(token_list, verbose=0)\n",
+        "\tpred_classes = model.predict(token_list, verbose=0)\n",
+        "\tpredicted = np.argmax(pred_classes,axis=-1)\n",
+        "\n",
         "\toutput_word = \"\"\n",
         "\tfor word, index in tokenizer.word_index.items():\n",
         "\t\tif index == predicted:\n",
@@ -306,17 +304,21 @@
         "\t\t\tbreak\n",
         "\tseed_text += \" \" + output_word\n",
         "print(seed_text)"
-      ],
-      "execution_count": 35,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "are you feeling lucky the hail the morning air where the place where we sat side by them spend oh my kellswater so fair for this one shadow on my wild throbbing breast hid her thousand treasures with such yet was seen for the song of the star of the very next day and mother i eyes are smiling sure tis like the morn in spring the landlord and the storied evening after live oh shed a tear in the high rocky slopes round the red came and slower and they would support her could not bring rosin the wheel leave where i was\n"
-          ],
-          "name": "stdout"
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "include_colab_link": true,
+      "name": "irish-songsmoredata.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/chapter8/irishsongs-generator.py
+++ b/chapter8/irishsongs-generator.py
@@ -29,7 +29,8 @@ next_words = 100
 for _ in range(next_words):
 	token_list = tokenizer.texts_to_sequences([seed_text])[0]
 	token_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')
-	predicted = model.predict_classes(token_list, verbose=0)
+	pred_classes = model.predict(token_list, verbose=0)
+	predicted = np.argmax(pred_classes, axis=-1)
 	output_word = ""
 	for word, index in tokenizer.word_index.items():
 		if index == predicted:

--- a/chapter8/irishsongs.py
+++ b/chapter8/irishsongs.py
@@ -64,7 +64,8 @@ next_words = 100
 for _ in range(next_words):
 	token_list = tokenizer.texts_to_sequences([seed_text])[0]
 	token_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')
-	predicted = model.predict_classes(token_list, verbose=0)
+	pred_classes = model.predict(token_list, verbose=0)
+	predicted = np.argmax(pred_classes, axis=-1)
 	output_word = ""
 	for word, index in tokenizer.word_index.items():
 		if index == predicted:


### PR DESCRIPTION
`model.predict_classes()` is depreciated 

replaced all instances of  `predicted = model.predict_classes(token_list)` with:

```
pred_classes = model.predict(token_list, verbose=0)
predicted = np.argmax(pred_classes, axis=-1)
```

as per [this stackoverflow ](https://stackoverflow.com/questions/68776790/model-predict-classes-is-deprecated-what-to-use-instead) discussion